### PR TITLE
Andy/handle task cancellation

### DIFF
--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -6,10 +6,11 @@ import "encoding/json"
 type MessageType string
 
 const (
-	MessageTypeTaskAssignment MessageType = "task_assignment"
-	MessageTypeTaskClaimed    MessageType = "task_claimed"
-	MessageTypeTaskFailed     MessageType = "task_failed"
-	MessageTypeHeartbeat      MessageType = "heartbeat"
+	MessageTypeTaskAssignment   MessageType = "task_assignment"
+	MessageTypeTaskClaimed      MessageType = "task_claimed"
+	MessageTypeTaskFailed       MessageType = "task_failed"
+	MessageTypeTaskCancellation MessageType = "task_cancellation"
+	MessageTypeHeartbeat        MessageType = "heartbeat"
 )
 
 // WebSocketMessage is the base structure for all WebSocket messages

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -40,3 +40,8 @@ type TaskFailedMessage struct {
 	TaskID  string `json:"task_id"`
 	Message string `json:"message"`
 }
+
+// TaskCancellationMessage is sent from server to worker to cancel a running task
+type TaskCancellationMessage struct {
+	TaskID string `json:"task_id"`
+}


### PR DESCRIPTION
## Handle task cancellation

Adds support for receiving `task_cancellation` messages from the server via WebSocket and gracefully cancelling running tasks.

### Changes

**Message types** (`internal/types/messages.go`):
- Added `MessageTypeTaskCancellation` and `TaskCancellationMessage` struct

**Worker** (`internal/worker/worker.go`):
- Handle `task_cancellation` messages in the WebSocket message handler
- `handleTaskCancellation`: looks up the task's cancel function and invokes it
- `executeTask`: distinguishes cancellation from genuine failures — cancelled tasks no longer send a `TaskFailed` message to the server
- `executeTaskInDocker`: uses a background context (with timeout) for container cleanup so removal succeeds even when the task context is already cancelled
- `executeTaskInDocker`: explicitly stops the running container when the task context is cancelled during `ContainerWait`

_This PR was generated with [Oz](https://www.warp.dev/oz)._
