### PR TITLE
make sure we use a properly generated API key from the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Self-hosted worker for Warp ambient agents.
 
 ## Requirements
 
-- Docker daemon running on localhost
+- Docker daemon (accessible via socket or TCP)
 - Service account API key with team scope
 - Network egress to warp-server
 
@@ -39,6 +39,29 @@ warp-agent-worker --api-key "wk-abc123" --worker-id "my-worker"
 ```bash
 export WARP_API_KEY="wk-abc123"
 warp-agent-worker --worker-id "my-worker"
+```
+
+## Docker Connectivity
+
+The worker automatically discovers the Docker daemon using standard Docker client mechanisms, in this order:
+
+1. **`DOCKER_HOST`** environment variable (e.g., `unix:///var/run/docker.sock`, `tcp://localhost:2375`)
+2. **Default socket location** (`/var/run/docker.sock` on Linux, `~/.docker/run/docker.sock` for rootless)
+3. **Docker context** via `DOCKER_CONTEXT` environment variable
+4. **Config file** (`~/.docker/config.json`) for context settings
+
+Additional supported environment variables:
+- `DOCKER_API_VERSION` - Specify Docker API version
+- `DOCKER_CERT_PATH` - Path to TLS certificates
+- `DOCKER_TLS_VERIFY` - Enable TLS verification
+
+### Example: Remote Docker Daemon
+
+```bash
+export DOCKER_HOST="tcp://remote-host:2376"
+export DOCKER_TLS_VERIFY=1
+export DOCKER_CERT_PATH="/path/to/certs"
+warp-agent-worker --api-key "wk-abc123" --worker-id "my-worker"
 ```
 
 ## License

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -28,9 +28,8 @@ type TaskAssignmentMessage struct {
 	DockerImage string `json:"docker_image,omitempty"`
 	// The "sidecar image" contains the warp agent binary and a couple other dependencies.
 	SidecarImage string `json:"sidecar_image,omitempty"`
-	GitHubToken  string `json:"github_token,omitempty"`
-	// APIKey is the API key for the sidecar to authenticate with the server (for UpdateAgentTask, etc.)
-	APIKey string `json:"api_key,omitempty"`
+	// EnvVars contains environment variables to set in the container (e.g. WARP_API_KEY, GITHUB_ACCESS_TOKEN)
+	EnvVars map[string]string `json:"env_vars,omitempty"`
 }
 
 // TaskClaimedMessage is sent from worker to server after successfully claiming a task

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -29,6 +29,8 @@ type TaskAssignmentMessage struct {
 	// The "sidecar image" contains the warp agent binary and a couple other dependencies.
 	SidecarImage string `json:"sidecar_image,omitempty"`
 	GitHubToken  string `json:"github_token,omitempty"`
+	// APIKey is the API key for the sidecar to authenticate with the server (for UpdateAgentTask, etc.)
+	APIKey string `json:"api_key,omitempty"`
 }
 
 // TaskClaimedMessage is sent from worker to server after successfully claiming a task

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -444,8 +444,15 @@ func (w *Worker) executeTaskInDocker(ctx context.Context, assignment *types.Task
 		}
 	}
 
+	// Use task-specific API key if provided, otherwise fall back to worker's API key
+	apiKey := assignment.APIKey
+	if apiKey == "" {
+		apiKey = w.config.APIKey
+		log.Warnf(ctx, "No task-specific API key provided for task %s, falling back to worker API key", task.ID)
+	}
+
 	envVars := []string{
-		fmt.Sprintf("WARP_API_KEY=%s", w.config.APIKey),
+		fmt.Sprintf("WARP_API_KEY=%s", apiKey),
 		fmt.Sprintf("TASK_ID=%s", task.ID),
 		"GIT_TERMINAL_PROMPT=0",
 		"GH_PROMPT_DISABLED=1",

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -444,25 +444,14 @@ func (w *Worker) executeTaskInDocker(ctx context.Context, assignment *types.Task
 		}
 	}
 
-	// Use task-specific API key if provided, otherwise fall back to worker's API key
-	apiKey := assignment.APIKey
-	if apiKey == "" {
-		apiKey = w.config.APIKey
-		log.Warnf(ctx, "No task-specific API key provided for task %s, falling back to worker API key", task.ID)
-	}
-
 	envVars := []string{
-		fmt.Sprintf("WARP_API_KEY=%s", apiKey),
 		fmt.Sprintf("TASK_ID=%s", task.ID),
 		"GIT_TERMINAL_PROMPT=0",
 		"GH_PROMPT_DISABLED=1",
 	}
 
-	if assignment.GitHubToken != "" {
-		log.Infof(ctx, "Setting GitHub token from assignment for task %s", task.ID)
-		envVars = append(envVars, fmt.Sprintf("GITHUB_ACCESS_TOKEN=%s", assignment.GitHubToken))
-	} else {
-		log.Warnf(ctx, "No GitHub token provided in assignment for task %s", task.ID)
+	for key, value := range assignment.EnvVars {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
 	}
 
 	cmd := []string{


### PR DESCRIPTION
The worker binary is authenticated with a service account API key. I was passing that same key into the container, but that doesn't work for user-owned tasks. We need to accept a user-generated key. The corresponding change to pass the key is done in warpdotdev/warp-server#8039