### PR TITLE
make sure you cannot pass `--worker-id "warp"`

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,6 +29,10 @@ func main() {
 		kong.Vars{},
 	)
 
+	if CLI.WorkerID == "warp" {
+		log.Fatalf(ctx, "Invalid worker-id: 'warp' is a reserved value and cannot be used")
+	}
+
 	log.SetLevel(CLI.LogLevel)
 
 	config := worker.Config{

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/alecthomas/kong"
@@ -29,8 +30,8 @@ func main() {
 		kong.Vars{},
 	)
 
-	if CLI.WorkerID == "warp" {
-		log.Fatalf(ctx, "Invalid worker-id: 'warp' is a reserved value and cannot be used")
+	if strings.HasPrefix(CLI.WorkerID, "warp") {
+		log.Fatalf(ctx, "Invalid worker-id: values starting with 'warp' are reserved and cannot be used")
 	}
 
 	log.SetLevel(CLI.LogLevel)


### PR DESCRIPTION
## Description 
"warp" is a special value that means warp-hosted workers. Therefore, a self-hosted worker with this ID will never consume any tasks. This will inform the user of that.

This will be especially helpful when we have Warp the logistics company and Warp the payroll company as customers 😂 

## Testing

<img width="836" height="126" alt="Screenshot 2026-01-16 at 05 53 53" src="https://github.com/user-attachments/assets/cc16e7b7-6873-4529-8c47-07f9ecbc76e9" />
