### PR TITLE
add --no-cleanup option to keep failed containers

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -39,6 +39,7 @@ type Config struct {
 	WebSocketURL  string
 	ServerRootURL string
 	LogLevel      string
+	NoCleanup     bool
 }
 
 type Worker struct {
@@ -502,7 +503,7 @@ func (w *Worker) executeTaskInDocker(ctx context.Context, assignment *types.Task
 	log.Debugf(ctx, "Created Docker container: %s", containerID)
 
 	defer func() {
-		if containerID != "" {
+		if containerID != "" && !w.config.NoCleanup {
 			if removeErr := dockerClient.ContainerRemove(ctx, containerID, container.RemoveOptions{Force: true}); removeErr != nil {
 				log.Debugf(ctx, "Container %s already removed or removal failed: %v", containerID, removeErr)
 			}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ var CLI struct {
 	WebSocketURL  string `default:"wss://app.warp.dev/api/v1/selfhosted/worker/ws" hidden:""`
 	ServerRootURL string `default:"https://app.warp.dev" hidden:""`
 	LogLevel      string `help:"Log level (debug, info, warn, error)" default:"info" enum:"debug,info,warn,error"`
+	NoCleanup     bool   `help:"Do not remove containers after execution (for debugging)"`
 }
 
 func main() {
@@ -42,6 +43,7 @@ func main() {
 		WebSocketURL:  CLI.WebSocketURL,
 		ServerRootURL: CLI.ServerRootURL,
 		LogLevel:      CLI.LogLevel,
+		NoCleanup:     CLI.NoCleanup,
 	}
 
 	w, err := worker.New(ctx, config)


### PR DESCRIPTION
The containers for agent tasks get cleaned up by the worker process. That's unfortunate if you want to view the logs for debugging. Add a CLI option `--no-cleanup` to suppress this.