### PR TITLE
add --volumes option which mirrors the docker CLI option

### DIFF
--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -58,10 +58,10 @@ type AmbientAgentConfig struct {
 
 // Task represents an ambient agent job.
 type Task struct {
-	ID                  string               `json:"id"`
-	Title               string               `json:"title"`
-	Definition          TaskDefinition       `json:"task_definition"`
-	CreatedAt           time.Time            `json:"created_at"`
-	UpdatedAt           time.Time            `json:"updated_at"`
-	AgentConfigSnapshot *AmbientAgentConfig  `json:"agent_config_snapshot,omitempty"`
+	ID                  string              `json:"id"`
+	Title               string              `json:"title"`
+	Definition          TaskDefinition      `json:"task_definition"`
+	CreatedAt           time.Time           `json:"created_at"`
+	UpdatedAt           time.Time           `json:"updated_at"`
+	AgentConfigSnapshot *AmbientAgentConfig `json:"agent_config_snapshot,omitempty"`
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -40,6 +40,7 @@ type Config struct {
 	ServerRootURL string
 	LogLevel      string
 	NoCleanup     bool
+	Volumes       []string
 }
 
 type Worker struct {
@@ -488,10 +489,14 @@ func (w *Worker) executeTaskInDocker(ctx context.Context, assignment *types.Task
 		WorkingDir: "/workspace",
 	}
 
+	binds := []string{
+		fmt.Sprintf("%s:/agent:ro", volumeName),
+	}
+	// Add user-configured volumes
+	binds = append(binds, w.config.Volumes...)
+
 	hostConfig := &container.HostConfig{
-		Binds: []string{
-			fmt.Sprintf("%s:/agent:ro", volumeName),
-		},
+		Binds: binds,
 	}
 
 	resp, err := dockerClient.ContainerCreate(ctx, containerConfig, hostConfig, nil, nil, "")

--- a/main.go
+++ b/main.go
@@ -13,12 +13,13 @@ import (
 )
 
 var CLI struct {
-	APIKey        string `help:"API key for authentication" env:"WARP_API_KEY" required:""`
-	WorkerID      string `help:"Worker host identifier" required:""`
-	WebSocketURL  string `default:"wss://app.warp.dev/api/v1/selfhosted/worker/ws" hidden:""`
-	ServerRootURL string `default:"https://app.warp.dev" hidden:""`
-	LogLevel      string `help:"Log level (debug, info, warn, error)" default:"info" enum:"debug,info,warn,error"`
-	NoCleanup     bool   `help:"Do not remove containers after execution (for debugging)"`
+	APIKey        string   `help:"API key for authentication" env:"WARP_API_KEY" required:""`
+	WorkerID      string   `help:"Worker host identifier" required:""`
+	WebSocketURL  string   `default:"wss://app.warp.dev/api/v1/selfhosted/worker/ws" hidden:""`
+	ServerRootURL string   `default:"https://app.warp.dev" hidden:""`
+	LogLevel      string   `help:"Log level (debug, info, warn, error)" default:"info" enum:"debug,info,warn,error"`
+	NoCleanup     bool     `help:"Do not remove containers after execution (for debugging)"`
+	Volumes       []string `help:"Volume mounts for task containers (format: HOST_PATH:CONTAINER_PATH or HOST_PATH:CONTAINER_PATH:MODE)" short:"v"`
 }
 
 func main() {
@@ -44,6 +45,7 @@ func main() {
 		ServerRootURL: CLI.ServerRootURL,
 		LogLevel:      CLI.LogLevel,
 		NoCleanup:     CLI.NoCleanup,
+		Volumes:       CLI.Volumes,
 	}
 
 	w, err := worker.New(ctx, config)
@@ -70,4 +72,3 @@ func main() {
 
 	log.Infof(ctx, "Worker shutdown complete")
 }
-


### PR DESCRIPTION
Allow the user to pass through arbitrary volumes. This is useful, for example, for mounting very large artifacts that can't be in the `github_repos`.