### PR TITLE
Add CI in github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.25.0'
+      - name: Check code formatting
+        run: |
+          if [ -n "$(gofmt -s -l .)" ]; then
+            echo "Go code is not formatted:"
+            gofmt -s -d .
+            exit 1
+          fi
+      - name: Run go vet
+        run: go vet ./...
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+      - name: Run golangci-lint
+        run: golangci-lint run
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.25.0'
+      - name: Build
+        run: go build -v ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,20 @@ jobs:
           go-version: '1.25.0'
       - name: Build
         run: go build -v ./...
+
+  docker:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: warpdotdev/warp-agent-worker:latest

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -50,12 +50,12 @@ type TaskDefinition struct {
 
 // AmbientAgentConfig represents the agent configuration
 type AmbientAgentConfig struct {
-	EnvironmentID *string                      `json:"environment_id,omitempty"`
-	BasePrompt    *string                      `json:"base_prompt,omitempty"`
-	ModelID       *string                      `json:"model_id,omitempty"`
-	ProfileID     *string                      `json:"profile_id,omitempty"`
-	SkillSpec     *string                      `json:"skill_spec,omitempty"`
-	MCPServers    map[string]json.RawMessage   `json:"mcp_servers,omitempty"`
+	EnvironmentID *string                    `json:"environment_id,omitempty"`
+	BasePrompt    *string                    `json:"base_prompt,omitempty"`
+	ModelID       *string                    `json:"model_id,omitempty"`
+	ProfileID     *string                    `json:"profile_id,omitempty"`
+	SkillSpec     *string                    `json:"skill_spec,omitempty"`
+	MCPServers    map[string]json.RawMessage `json:"mcp_servers,omitempty"`
 }
 
 // Task represents an ambient agent job.


### PR DESCRIPTION
this adds a simple verification step, linting and compiling. this runs on PRs to main. After merging to main, verification will run again and if that passes, push to Docker Hub

I verified that this fails when lint fails: https://github.com/warpdotdev/warp-agent-worker/actions/runs/21715086345/job/62628622122?pr=16


FYI this workflow needs a couple of secrets configured, `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. I don't think I can access/create credentials for our org except for personal credentials (which I assume we don't want).