### PR TITLE
Add support for additional sidecar volumes.

### DIFF
--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -21,6 +21,13 @@ type WebSocketMessage struct {
 	Data json.RawMessage `json:"data,omitempty"`
 }
 
+// SidecarMount describes an additional sidecar image to mount into the task container.
+type SidecarMount struct {
+	Image     string `json:"image"`      // Docker image to pull.
+	MountPath string `json:"mount_path"` // Path to mount the sidecar filesystem in the task container.
+	ReadWrite bool   `json:"read_write"` // If false (default), the mount is read-only.
+}
+
 // TaskAssignmentMessage is sent from server to worker when a task is available
 type TaskAssignmentMessage struct {
 	TaskID      string `json:"task_id"`
@@ -30,6 +37,8 @@ type TaskAssignmentMessage struct {
 	SidecarImage string `json:"sidecar_image,omitempty"`
 	// EnvVars contains environment variables to set in the container (e.g. WARP_API_KEY, GITHUB_ACCESS_TOKEN)
 	EnvVars map[string]string `json:"env_vars,omitempty"`
+	// AdditionalSidecars is a list of extra sidecar images to mount into the task container.
+	AdditionalSidecars []SidecarMount `json:"additional_sidecars,omitempty"`
 }
 
 // TaskClaimedMessage is sent from worker to server after successfully claiming a task


### PR DESCRIPTION
## Description

Adds a generic mechanism for the server to specify additional sidecar images to mount into task containers. The server sends a list of `AdditionalSidecars` (image + mount path pairs) in the task assignment, and the worker pulls each image, extracts its filesystem into a digest-keyed Docker volume (with caching), and mounts it into the container.

The first use case is mounting an Xvfb sidecar at `/mnt/xvfb-sidecar` for computer use support, but the mechanism is intentionally generic so future sidecars can be added without worker-side changes.

The server-side changes that populate `AdditionalSidecars` are in warpdotdev/warp-server (branch `david/support-for-xvfb-in-self-hosted-workers`).

## Testing

- [x] Tested locally with a self-hosted worker and verified the xvfb sidecar volume is created, cached, and mounted correctly.

Co-Authored-By: Warp <agent@warp.dev>