### PR TITLE
publish multi-platform image to docker hub in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,4 +53,5 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: warpdotdev/warp-agent-worker:latest


### PR DESCRIPTION
ARM is not unpopular for linux servers. This is distributed as a docker image so we should publish an ARM image