### PR TITLE
Update README with Oz branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Self-hosted worker for Oz cloud agents.
 
+📖 **[Documentation](https://docs.warp.dev/agent-platform/cloud-agents/self-hosting)**
+
 ## Overview
 
 `warp-agent-worker` is a daemon that connects to Oz via WebSocket to receive and execute cloud agent tasks on self-hosted infrastructure.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # warp-agent-worker
 
-Self-hosted worker for Warp ambient agents.
+Self-hosted worker for Oz cloud agents.
 
 ## Overview
 
-`warp-agent-worker` is a daemon that connects to warp-server via WebSocket to receive and execute ambient agent tasks on self-hosted infrastructure.
+`warp-agent-worker` is a daemon that connects to Oz via WebSocket to receive and execute cloud agent tasks on self-hosted infrastructure.
 
 ## Requirements
 


### PR DESCRIPTION
Update README to use Oz product branding:

- Changed "Warp ambient agents" → "Oz cloud agents"
- Changed "warp-server" → "Oz"

Technical details (Docker images, env vars, binary names, copyright) remain unchanged as they refer to infrastructure/company rather than product branding.

Co-Authored-By: Warp <agent@warp.dev>