### PR TITLE
try to pull images with same platform as docker daemon

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -362,7 +362,7 @@ func (w *Worker) executeTask(ctx context.Context, assignment *types.TaskAssignme
 // pullImage pulls a Docker image. If authStr is non-empty, it will be used for registry authentication.
 // Docker only downloads changed layers, so this is efficient even if the image exists locally.
 func (w *Worker) pullImage(ctx context.Context, imageName string, authStr string) error {
-	log.Infof(ctx, "Pulling image: %s for platform %s", imageName, w.platform)
+	log.Infof(ctx, "Pulling image: %s", imageName)
 	pullOptions := image.PullOptions{
 		Platform:     w.platform,
 		RegistryAuth: authStr,


### PR DESCRIPTION
Hard-coding `linux/amd64` for the image platform is a bad idea. ARM servers will want to run their native architecture for better performance and ARM linux servers are not uncommon.