### PR TITLE
Support passing environment variables in to agent containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,30 @@ go build -o oz-agent-worker
 ./oz-agent-worker --api-key "wk-abc123" --worker-id "my-worker"
 ```
 
+## Environment Variables for Task Containers
+
+Use `-e` / `--env` to pass environment variables into task containers:
+
+```bash
+# Explicit key=value
+oz-agent-worker --api-key "wk-abc123" --worker-id "my-worker" -e MY_SECRET=hunter2
+
+# Pass through from host environment
+export MY_SECRET=hunter2
+oz-agent-worker --api-key "wk-abc123" --worker-id "my-worker" -e MY_SECRET
+
+# Multiple variables
+oz-agent-worker --api-key "wk-abc123" --worker-id "my-worker" -e FOO=bar -e BAZ=qux
+```
+
+When using Docker to run the worker, note that `-e` flags for the worker itself (task containers) are passed as arguments, while `-e` flags for the worker container use Docker's syntax:
+
+```bash
+docker run -v /var/run/docker.sock:/var/run/docker.sock \
+  -e WARP_API_KEY="wk-abc123" \
+  warpdotdev/oz-agent-worker --worker-id "my-worker" -e MY_SECRET=hunter2
+```
+
 ## Docker Connectivity
 
 The worker automatically discovers the Docker daemon using standard Docker client mechanisms, in this order:

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -43,6 +43,7 @@ type Config struct {
 	LogLevel      string
 	NoCleanup     bool
 	Volumes       []string
+	Env           map[string]string
 }
 
 type Worker struct {
@@ -499,6 +500,11 @@ func (w *Worker) executeTaskInDocker(ctx context.Context, assignment *types.Task
 	}
 
 	for key, value := range assignment.EnvVars {
+		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
+	}
+
+	// Append user-specified CLI env vars last so they take precedence.
+	for key, value := range w.config.Env {
 		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
 	}
 


### PR DESCRIPTION
This adds a mechanism for passing environment variables in to self-hosted agents. The intent is that this is used for:
* Host-specific configuration (e.g. pointing tools at a specific mounted volume)
* Injecting secrets which are _not_ managed by Warp

The configuration syntax follows the Docker CLI:
* `--env KEY=value` to set an environment variable directly
* `--env KEY` to inherit a value from the host environment
* `-e` as a shorthand

## Testing

I ran a self-hosted worker locally with the `--env` flag and asked an agent to print all environment variables.