### PR TITLE
Release workflow for worker binaries

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,71 @@
+name: Build Release
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build:
+    name: "Build ${{ matrix.goos }} ${{ matrix.goarch }}"
+    runs-on: namespace-profile-ubuntu-small
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+          - goos: windows
+            goarch: amd64
+          - goos: windows
+            goarch: arm64
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+      
+      - name: Install Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+          # Use the Namespace Go cache
+          cache: false
+    
+      - name: Set up build cache
+        uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: go
+
+      - name: Build
+        env:
+          CGO_ENABLED: '0'
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          binary="oz-agent-worker"
+          if [ "$GOOS" = "windows" ]; then
+            binary="oz-agent-worker.exe"
+          fi
+          go build -o "$binary" .
+
+      - name: Archive
+        run: |
+          prefix="oz-agent-worker-${{ matrix.goos }}-${{ matrix.goarch }}"
+          if [ "${{ matrix.goos }}" = "windows" ]; then
+            zip "${prefix}.zip" oz-agent-worker.exe
+          else
+            tar czf "${prefix}.tar.gz" oz-agent-worker
+            tar cJf "${prefix}.tar.xz" oz-agent-worker
+          fi
+
+      - name: Upload artifact
+        uses: namespace-actions/upload-artifact@v1
+        with:
+          name: oz-agent-worker-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: |
+            oz-agent-worker-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
+            oz-agent-worker-${{ matrix.goos }}-${{ matrix.goarch }}.tar.xz
+            oz-agent-worker-${{ matrix.goos }}-${{ matrix.goarch }}.zip

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -1,0 +1,32 @@
+name: Create Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    uses: ./.github/workflows/build_release.yml
+
+  release:
+    needs: build
+    runs-on: namespace-profile-ubuntu-small
+    permissions:
+      contents: write
+    steps:
+      - name: Generate tag name
+        id: tag
+        run: echo "name=v$(date -u +'%Y-%m-%d-%H-%M-%S')" >> "$GITHUB_OUTPUT"
+
+      - name: Download artifacts
+        uses: namespace-actions/download-artifact@v1
+        with:
+          path: artifacts
+
+      - name: Create release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.name }}
+          target_commitish: ${{ github.sha }}
+          generate_release_notes: true
+          files: artifacts/**/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/warpdotdev/oz-agent-worker
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/alecthomas/kong v1.13.0

--- a/script/test-build-release-workflow
+++ b/script/test-build-release-workflow
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Dry-run the build_release workflow locally using nektos/act.
+# Usage: script/test-build-release-workflow
+
+set -euo pipefail
+
+act workflow_dispatch -W .github/workflows/build_release.yml --container-architecture linux/amd64 -P namespace-profile-ubuntu-small=catthehacker/ubuntu:act-latest "$@"


### PR DESCRIPTION
## Description

This sets up a simple release workflow for publishing `oz-agent-worker` binaries.

There are two components:
1. A `build_release` workflow which creates the binaries, and can be dispatched off any branch
2. A `create_release` workflow which sets up the actual release

## Testing

I used the included script to validate the builds and workflow syntax, but it can't run locally for real (`act` doesn't stub artifact creation as far as I can tell). Once this merges, I'll run the build workflow and confirm the artifacts are correct.