### PR TITLE
Release tagged Docker images

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -2,7 +2,28 @@ name: Build Release
 
 on:
   workflow_dispatch:
+    inputs:
+      docker_tag:
+        description: 'Docker image tag (leave empty to skip Docker push)'
+        required: false
+        default: ''
+        type: string
   workflow_call:
+    inputs:
+      docker_tag:
+        description: 'Docker image tag (leave empty to skip Docker push)'
+        required: false
+        default: ''
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
+    outputs:
+      image:
+        description: 'Full Docker image reference'
+        value: ${{ jobs.docker.outputs.image }}
 
 jobs:
   build:
@@ -69,3 +90,35 @@ jobs:
             oz-agent-worker-${{ matrix.goos }}-${{ matrix.goarch }}.tar.gz
             oz-agent-worker-${{ matrix.goos }}-${{ matrix.goarch }}.tar.xz
             oz-agent-worker-${{ matrix.goos }}-${{ matrix.goarch }}.zip
+
+  docker:
+    name: Build and push Docker image
+    runs-on: namespace-profile-ubuntu-small
+    outputs:
+      image: "warpdotdev/oz-agent-worker@${{ steps.push.outputs.digest }}"
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          provenance: mode=max
+          sbom: true
+          # Only push tagged images. When not pushing, we need to provide a fallback output
+          # as multi-platform images can't be loaded into the local Docker store by default.
+          # See https://docs.docker.com/reference/cli/docker/buildx/build/#docker
+          outputs: ${{ inputs.docker_tag != '' && 'type=registry' || 'type=local,dest=built-images' }}
+          platforms: linux/amd64,linux/arm64
+          tags: warpdotdev/oz-agent-worker:${{ inputs.docker_tag || github.sha }}
+          labels:
+            dev.warp.worker-commit=${{ github.sha }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -4,29 +4,42 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  generate-tag:
     if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-    uses: ./.github/workflows/build_release.yml
-
-  release:
-    needs: build
     runs-on: namespace-profile-ubuntu-small
-    permissions:
-      contents: write
+    outputs:
+      tag_name: ${{ steps.tag.outputs.name }}
     steps:
       - name: Generate tag name
         id: tag
         run: echo "name=v$(date -u +'%Y-%m-%d-%H-%M-%S')" >> "$GITHUB_OUTPUT"
 
+  build:
+    needs: generate-tag
+    uses: ./.github/workflows/build_release.yml
+    secrets: inherit
+    with:
+      docker_tag: ${{ needs.generate-tag.outputs.tag_name }}
+
+  release:
+    needs: [generate-tag, build]
+    runs-on: namespace-profile-ubuntu-small
+    permissions:
+      contents: write
+    steps:
       - name: Download artifacts
         uses: namespace-actions/download-artifact@v1
         with:
+          # Only download release artifacts, not Docker image metadata.
+          pattern: oz-agent-worker-*
           path: artifacts
 
       - name: Create release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.tag.outputs.name }}
+          tag_name: ${{ needs.generate-tag.outputs.tag_name }}
           target_commitish: ${{ github.sha }}
           generate_release_notes: true
+          append_body: true
+          body: "**Docker image:** `${{ needs.build.outputs.image }}`"
           files: artifacts/**/*


### PR DESCRIPTION
This updates the worker release workflow to also build and push a tagged Docker image.

Doing so allows pinning the worker to a specific version, even when using Docker.

Tested at https://github.com/warpdotdev/oz-agent-worker/actions/runs/23048873617
