### PR TITLE
feat: add --target-dir flag to direct backend

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,6 +41,7 @@ type DockerConfig struct {
 // DirectConfig holds direct-backend-specific configuration.
 type DirectConfig struct {
 	WorkspaceRoot   string     `yaml:"workspace_root"`
+	TargetDir       string     `yaml:"target_dir"`
 	OzPath          string     `yaml:"oz_path"`
 	SetupCommand    string     `yaml:"setup_command"`
 	TeardownCommand string     `yaml:"teardown_command"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -235,6 +235,31 @@ backend:
 	}
 }
 
+func TestLoadDirectConfigWithTargetDir(t *testing.T) {
+	path := writeTestConfig(t, `
+worker_id: "direct-worker"
+backend:
+  direct:
+    target_dir: "/home/user/myrepo"
+    setup_command: "/opt/setup.sh"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Backend.Direct == nil {
+		t.Fatal("expected direct backend to be set")
+	}
+	if cfg.Backend.Direct.TargetDir != "/home/user/myrepo" {
+		t.Errorf("target_dir = %q, want %q", cfg.Backend.Direct.TargetDir, "/home/user/myrepo")
+	}
+	if cfg.Backend.Direct.WorkspaceRoot != "" {
+		t.Errorf("workspace_root should be empty, got %q", cfg.Backend.Direct.WorkspaceRoot)
+	}
+}
+
 func TestLoadBothBackendsError(t *testing.T) {
 	path := writeTestConfig(t, `
 backend:

--- a/internal/worker/direct.go
+++ b/internal/worker/direct.go
@@ -34,6 +34,7 @@ func hostBaseEnv() []string {
 // DirectBackendConfig holds configuration specific to the direct (non-containerized) backend.
 type DirectBackendConfig struct {
 	WorkspaceRoot   string
+	TargetDir       string // If set, run all tasks in this directory instead of creating per-task workspaces.
 	OzPath          string // Path to the oz CLI binary. If empty, looks up "oz" in PATH.
 	SetupCommand    string
 	TeardownCommand string
@@ -59,13 +60,25 @@ func NewDirectBackend(ctx context.Context, config DirectBackendConfig) (*DirectB
 	}
 	log.Infof(ctx, "Using oz CLI at: %s", ozPath)
 
-	if config.WorkspaceRoot == "" {
-		config.WorkspaceRoot = defaultWorkspaceRoot
-	}
+	if config.TargetDir != "" {
+		// Validate that the target directory exists.
+		info, err := os.Stat(config.TargetDir)
+		if err != nil {
+			return nil, fmt.Errorf("target directory %s does not exist: %w", config.TargetDir, err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("target directory %s is not a directory", config.TargetDir)
+		}
+		log.Infof(ctx, "Using shared target directory: %s (per-task workspace isolation disabled)", config.TargetDir)
+	} else {
+		if config.WorkspaceRoot == "" {
+			config.WorkspaceRoot = defaultWorkspaceRoot
+		}
 
-	// Ensure workspace root exists.
-	if err := os.MkdirAll(config.WorkspaceRoot, 0755); err != nil {
-		return nil, fmt.Errorf("failed to create workspace root %s: %w", config.WorkspaceRoot, err)
+		// Ensure workspace root exists.
+		if err := os.MkdirAll(config.WorkspaceRoot, 0755); err != nil {
+			return nil, fmt.Errorf("failed to create workspace root %s: %w", config.WorkspaceRoot, err)
+		}
 	}
 
 	return &DirectBackend{
@@ -78,14 +91,27 @@ func NewDirectBackend(ctx context.Context, config DirectBackendConfig) (*DirectB
 func (b *DirectBackend) ExecuteTask(ctx context.Context, params *TaskParams) error {
 	taskID := params.TaskID
 
-	// 1. Create per-task workspace directory.
-	workspaceDir := filepath.Join(b.config.WorkspaceRoot, taskID)
-	if err := os.MkdirAll(workspaceDir, 0755); err != nil {
-		return fmt.Errorf("failed to create workspace directory: %w", err)
+	// Determine working directory: shared target dir or per-task workspace.
+	var workspaceDir string
+	usingTargetDir := b.config.TargetDir != ""
+
+	if usingTargetDir {
+		workspaceDir = b.config.TargetDir
+	} else {
+		// Create per-task workspace directory.
+		workspaceDir = filepath.Join(b.config.WorkspaceRoot, taskID)
+		if err := os.MkdirAll(workspaceDir, 0755); err != nil {
+			return fmt.Errorf("failed to create workspace directory: %w", err)
+		}
+		log.Infof(ctx, "Created workspace: %s", workspaceDir)
 	}
-	log.Infof(ctx, "Created workspace: %s", workspaceDir)
 
 	defer func() {
+		if usingTargetDir {
+			// Don't clean up the shared target directory.
+			b.runTeardownIfConfigured(ctx, taskID, workspaceDir)
+			return
+		}
 		if b.config.NoCleanup {
 			log.Infof(ctx, "Skipping cleanup for workspace: %s", workspaceDir)
 			return
@@ -102,6 +128,7 @@ func (b *DirectBackend) ExecuteTask(ctx context.Context, params *TaskParams) err
 	if err := envFile.Close(); err != nil {
 		return fmt.Errorf("failed to close environment file: %w", err)
 	}
+	defer os.Remove(envFilePath)
 
 	// 3. Build environment variables: common + config-level.
 	envVars := make([]string, len(params.EnvVars))
@@ -159,6 +186,9 @@ func (b *DirectBackend) ExecuteTask(ctx context.Context, params *TaskParams) err
 
 // Shutdown cleans up any workspace directories left behind under the workspace root.
 func (b *DirectBackend) Shutdown(ctx context.Context) {
+	if b.config.WorkspaceRoot == "" {
+		return
+	}
 	entries, err := os.ReadDir(b.config.WorkspaceRoot)
 	if err != nil {
 		if !os.IsNotExist(err) {
@@ -176,20 +206,25 @@ func (b *DirectBackend) Shutdown(ctx context.Context) {
 	}
 }
 
+// runTeardownIfConfigured runs the teardown command if one is configured.
+func (b *DirectBackend) runTeardownIfConfigured(ctx context.Context, taskID, workspaceDir string) {
+	if b.config.TeardownCommand == "" {
+		return
+	}
+	teardownEnv := []string{
+		fmt.Sprintf("OZ_WORKSPACE_ROOT=%s", workspaceDir),
+		"OZ_WORKER_BACKEND=direct",
+		fmt.Sprintf("OZ_RUN_ID=%s", taskID),
+	}
+	log.Infof(ctx, "Running teardown command: %s", b.config.TeardownCommand)
+	if err := b.runCommand(ctx, b.config.TeardownCommand, workspaceDir, teardownEnv); err != nil {
+		log.Warnf(ctx, "Teardown command failed: %v", err)
+	}
+}
+
 // cleanup runs the teardown command (if configured) and removes the workspace directory.
 func (b *DirectBackend) cleanup(ctx context.Context, taskID, workspaceDir string) {
-	if b.config.TeardownCommand != "" {
-		teardownEnv := []string{
-			fmt.Sprintf("OZ_WORKSPACE_ROOT=%s", workspaceDir),
-			"OZ_WORKER_BACKEND=direct",
-			fmt.Sprintf("OZ_RUN_ID=%s", taskID),
-		}
-
-		log.Infof(ctx, "Running teardown command: %s", b.config.TeardownCommand)
-		if err := b.runCommand(ctx, b.config.TeardownCommand, workspaceDir, teardownEnv); err != nil {
-			log.Warnf(ctx, "Teardown command failed: %v", err)
-		}
-	}
+	b.runTeardownIfConfigured(ctx, taskID, workspaceDir)
 
 	log.Infof(ctx, "Removing workspace: %s", workspaceDir)
 	if err := os.RemoveAll(workspaceDir); err != nil {

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ var CLI struct {
 	WebSocketURL       string   `default:"wss://oz.warp.dev/api/v1/selfhosted/worker/ws" hidden:""`
 	ServerRootURL      string   `default:"https://app.warp.dev" hidden:""`
 	LogLevel           string   `help:"Log level (debug, info, warn, error)" default:"info" enum:"debug,info,warn,error"`
+	TargetDir          string   `help:"Run all tasks in this directory instead of creating per-task workspaces (direct backend only)"`
 	NoCleanup          bool     `help:"Do not remove containers after execution (for debugging)"`
 	Volumes            []string `help:"Volume mounts for task containers (format: HOST_PATH:CONTAINER_PATH or HOST_PATH:CONTAINER_PATH:MODE)" short:"v"`
 	Env                []string `help:"Environment variables for task containers (format: KEY=VALUE or KEY to pass through from host)" short:"e"`
@@ -152,16 +153,23 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 			mergedEnv[k] = v
 		}
 
-		var workspaceRoot, ozPath, setupCmd, teardownCmd string
+		var workspaceRoot, targetDir, ozPath, setupCmd, teardownCmd string
 		if fileConfig != nil && fileConfig.Backend.Direct != nil {
 			workspaceRoot = fileConfig.Backend.Direct.WorkspaceRoot
+			targetDir = fileConfig.Backend.Direct.TargetDir
 			ozPath = fileConfig.Backend.Direct.OzPath
 			setupCmd = fileConfig.Backend.Direct.SetupCommand
 			teardownCmd = fileConfig.Backend.Direct.TeardownCommand
 		}
 
+		// CLI --target-dir overrides config file.
+		if CLI.TargetDir != "" {
+			targetDir = CLI.TargetDir
+		}
+
 		wc.Direct = &worker.DirectBackendConfig{
 			WorkspaceRoot:   workspaceRoot,
+			TargetDir:       targetDir,
 			OzPath:          ozPath,
 			SetupCommand:    setupCmd,
 			TeardownCommand: teardownCmd,


### PR DESCRIPTION
## Summary
Add a `--target-dir` option for the direct backend that runs all tasks in a specified directory instead of creating per-task workspace subdirectories. This disables per-task workspace isolation for users who want the agent to operate against an existing directory (e.g. a pre-existing repo checkout).

## Changes
- **`internal/config/config.go`**: Add `target_dir` field to `DirectConfig` YAML schema.
- **`internal/worker/direct.go`**:
  - Add `TargetDir` to `DirectBackendConfig`.
  - `NewDirectBackend`: validate target dir exists at startup; skip workspace root setup when target dir is set.
  - `ExecuteTask`: use target dir as working directory when set, skipping per-task subdirectory creation. Shared directory is never deleted on cleanup (teardown commands still run).
  - `Shutdown`: early-return when `WorkspaceRoot` is empty (target-dir mode) to avoid spurious warnings.
  - Extract `runTeardownIfConfigured` from `cleanup` to reuse in both code paths.
  - Add `defer os.Remove(envFilePath)` to clean up temp env files explicitly (previously relied on workspace dir removal).
- **`main.go`**: Add `--target-dir` CLI flag, wire through `mergeConfig` with CLI > config file precedence.
- **`internal/config/config_test.go`**: Add test for `target_dir` config parsing.

## Usage
```bash
# CLI flag
oz-agent-worker --backend direct --target-dir /path/to/repo ...

# YAML config
backend:
  direct:
    target_dir: "/path/to/repo"
```

## Testing
- `go build ./...` — compiles cleanly.
- `go test ./...` — all tests pass, including new `TestLoadDirectConfigWithTargetDir`.
- Manual verification: when `target_dir` is set, no per-task subdirectory is created; when unset, behavior is unchanged.

---
Co-Authored-By: Oz <oz-agent@warp.dev>
[Conversation](https://staging.warp.dev/conversation/1af96766-cb39-4646-a53f-ca875ffa8d74)