### PR TITLE
Inherit proxy env vars by default in direct backend

### DIFF
--- a/internal/worker/direct.go
+++ b/internal/worker/direct.go
@@ -17,7 +17,15 @@ const defaultWorkspaceRoot = "/var/lib/oz/workspaces"
 // defaultInheritedEnvVars are the host environment variables passed through to
 // tasks and scripts by default. Sensitive worker credentials are intentionally
 // excluded; additional variables can be opted in via the backend config.
-var defaultInheritedEnvVars = []string{"HOME", "TMPDIR", "PATH"}
+var defaultInheritedEnvVars = []string{
+	"HOME", "TMPDIR", "PATH",
+	// Proxy configuration: inherit standard proxy env vars so the oz CLI
+	// can route WebSocket and HTTPS traffic through corporate proxies.
+	"HTTP_PROXY", "http_proxy",
+	"HTTPS_PROXY", "https_proxy",
+	"NO_PROXY", "no_proxy",
+	"ALL_PROXY", "all_proxy",
+}
 
 // hostBaseEnv builds a minimal env slice from the host, containing only the
 // keys listed in defaultInheritedEnvVars.


### PR DESCRIPTION
## Description

Add standard proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY` and lowercase variants) to `defaultInheritedEnvVars` in the direct backend.

Previously, only `HOME`, `TMPDIR`, and `PATH` were inherited from the host process environment. Customers behind HTTP CONNECT proxies had to explicitly configure proxy env vars in `backend.direct.environment`, which is error-prone and non-obvious.

With this change, the oz CLI automatically inherits the worker's proxy settings. Explicit config entries still work as overrides.

**Related:** This is the companion fix to warpdotdev/warp-internal#23747 which fixes a port parsing bug in the websocket proxy code. Both fixes are needed to fully resolve the customer issue.

## Testing

- `go build ./...` succeeds
- `go test ./...` — all tests pass

_Conversation: https://staging.warp.dev/conversation/5cb48f52-5908-4cb5-bde3-3e5ce5dce30c_
_Run: https://oz.staging.warp.dev/runs/019d4076-25fb-78e4-ab78-459000d0cb34_

_This PR was generated with [Oz](https://warp.dev/oz)._
