### PR TITLE
Inherit proxy env vars by default in direct backend

### DIFF
--- a/internal/worker/direct.go
+++ b/internal/worker/direct.go
@@ -17,7 +17,15 @@ const defaultWorkspaceRoot = "/var/lib/oz/workspaces"
 // defaultInheritedEnvVars are the host environment variables passed through to
 // tasks and scripts by default. Sensitive worker credentials are intentionally
 // excluded; additional variables can be opted in via the backend config.
-var defaultInheritedEnvVars = []string{"HOME", "TMPDIR", "PATH"}
+//
+// Proxy env vars are included so that the oz CLI inherits the worker's proxy
+// configuration automatically, avoiding manual config duplication when the
+// worker is deployed behind an HTTP egress proxy.
+var defaultInheritedEnvVars = []string{
+	"HOME", "TMPDIR", "PATH",
+	"HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",
+	"http_proxy", "https_proxy", "no_proxy",
+}
 
 // hostBaseEnv builds a minimal env slice from the host, containing only the
 // keys listed in defaultInheritedEnvVars.

--- a/internal/worker/direct_test.go
+++ b/internal/worker/direct_test.go
@@ -1,0 +1,70 @@
+package worker
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestHostBaseEnvIncludesProxyVariables(t *testing.T) {
+	t.Setenv("HOME", "/home/agent")
+	t.Setenv("HTTP_PROXY", "http://proxy:80")
+	t.Setenv("HTTPS_PROXY", "http://proxy:80")
+	t.Setenv("NO_PROXY", "localhost,.svc.cluster.local")
+	t.Setenv("http_proxy", "http://proxy:80")
+	t.Setenv("https_proxy", "http://proxy:80")
+	t.Setenv("no_proxy", "localhost,.svc.cluster.local")
+
+	env := hostBaseEnv()
+
+	expected := map[string]string{
+		"HOME=/home/agent":                              "HOME should be inherited",
+		"HTTP_PROXY=http://proxy:80":                    "HTTP_PROXY should be inherited",
+		"HTTPS_PROXY=http://proxy:80":                   "HTTPS_PROXY should be inherited",
+		"NO_PROXY=localhost,.svc.cluster.local":         "NO_PROXY should be inherited",
+		"http_proxy=http://proxy:80":                    "http_proxy should be inherited",
+		"https_proxy=http://proxy:80":                   "https_proxy should be inherited",
+		"no_proxy=localhost,.svc.cluster.local":         "no_proxy should be inherited",
+	}
+
+	for entry, msg := range expected {
+		if !containsEnvEntry(env, entry) {
+			t.Fatalf("%s; got env=%v", msg, env)
+		}
+	}
+}
+
+func containsEnvEntry(env []string, want string) bool {
+	for _, entry := range env {
+		if strings.EqualFold(entry, want) || entry == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestHostBaseEnvOmitsUnsetVariables(t *testing.T) {
+	_ = os.Unsetenv("HTTP_PROXY")
+	_ = os.Unsetenv("HTTPS_PROXY")
+	_ = os.Unsetenv("NO_PROXY")
+	_ = os.Unsetenv("http_proxy")
+	_ = os.Unsetenv("https_proxy")
+	_ = os.Unsetenv("no_proxy")
+
+	env := hostBaseEnv()
+
+	for _, key := range []string{
+		"HTTP_PROXY=",
+		"HTTPS_PROXY=",
+		"NO_PROXY=",
+		"http_proxy=",
+		"https_proxy=",
+		"no_proxy=",
+	} {
+		for _, entry := range env {
+			if strings.HasPrefix(entry, key) {
+				t.Fatalf("did not expect %s in env=%v", key, env)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds proxy environment variables (`HTTP_PROXY`, `HTTPS_PROXY`, `http_proxy`, `https_proxy`, `NO_PROXY`, `no_proxy`) to `defaultInheritedEnvVars` in the direct backend, so the oz CLI automatically inherits the worker's proxy configuration.

## Problem

When the oz-agent-worker runs behind an HTTP egress proxy, the oz CLI child process does not inherit proxy env vars by default. Customers must manually duplicate all proxy env vars in the config file's `environment` section. Even when they do, the current `defaultInheritedEnvVars` only includes `HOME`, `TMPDIR`, and `PATH`, meaning proxy-related variables are excluded from `hostBaseEnv()` unless explicitly configured.

This causes the oz CLI's WebSocket connections (to `sessions.app.warp.dev` and `rtc.app.warp.dev`) to bypass the proxy, leading to connection timeouts in environments that only allow outbound traffic through an HTTP egress proxy.

## Changes

- **`internal/worker/direct.go`**: Added 6 proxy env var names to `defaultInheritedEnvVars`
- **`internal/worker/direct_test.go`**: Added tests verifying proxy vars are inherited when set and omitted when unset

## Related

This is part of a broader fix for WebSocket proxy support. The companion PR in `warp-internal` improves proxy connection logging and increases the session share timeout.

_Conversation: https://staging.warp.dev/conversation/d32a99cc-8075-4f75-81b5-41a501a7d9dd_
_Run: https://oz.staging.warp.dev/runs/019d450f-b460-7e69-bac7-73ef9b60676f_
_Plans:_
- _[Fix WebSocket proxy support for oz CLI session sharing behind HTTP proxies](https://staging.warp.dev/drive/notebook/HIvrlelvIBQ7Jg3s1VYBf7)_
_This PR was generated with [Oz](https://warp.dev/oz)._
