### PR TITLE
Do not assume a shell for the self-hosted worker

### DIFF
--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -107,7 +107,7 @@ func (b *DockerBackend) ExecuteTask(ctx context.Context, params *TaskParams) err
 	}
 
 	// Build Docker-specific command: entrypoint prefix + base args.
-	cmd := append([]string{"/bin/sh", "/agent/entrypoint.sh"}, params.BaseArgs...)
+	cmd := append([]string{"/agent/entrypoint.sh"}, params.BaseArgs...)
 
 	log.Debugf(ctx, "Creating Docker container with image=%s", imageName)
 


### PR DESCRIPTION
We shouldn't assume the entrypoint script runs under `/bin/sh`.