### PR TITLE
Propagate task conversation ID in self-hosted worker.

### DIFF
--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -40,6 +40,8 @@ type TaskAssignmentMessage struct {
 	EnvVars map[string]string `json:"env_vars,omitempty"`
 	// AdditionalSidecars is a list of extra sidecar images to mount into the task container.
 	AdditionalSidecars []SidecarMount `json:"additional_sidecars,omitempty"`
+	// ConversationID is the UUID of an existing AI conversation to continue.
+	ConversationID string `json:"conversation_id,omitempty"`
 }
 
 // TaskClaimedMessage is sent from worker to server after successfully claiming a task

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -375,6 +375,9 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		"--server-root-url",
 		w.config.ServerRootURL,
 	}
+	if assignment.ConversationID != "" {
+		baseArgs = append(baseArgs, "--conversation", assignment.ConversationID)
+	}
 	baseArgs = common.AugmentArgsForTask(task, baseArgs, common.TaskAugmentOptions{
 		IdleOnComplete: w.config.IdleOnComplete,
 	})


### PR DESCRIPTION
Conversation ID was being passed but ignored by the selfhosted worker (I assume this is not intentional).  
  
Besides probably being correct and what we want, selfishly need this to test cloud->cloud handoff with ./script/oz-local