### PR TITLE
Read conversation id from the task (instead of the TaskAssignmentMessage)

### DIFF
--- a/internal/common/task_utils.go
+++ b/internal/common/task_utils.go
@@ -114,6 +114,14 @@ func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions
 		args = append(args, "--idle-on-complete", idleOnComplete)
 	}
 
+	// If the server linked this task to an existing AI conversation, forward the id so the
+	// embedded warp CLI can resume that conversation's state (Oz or Claude Code).
+	if task.AgentConversationID != nil {
+		if id := strings.TrimSpace(*task.AgentConversationID); id != "" {
+			args = append(args, "--conversation", id)
+		}
+	}
+
 	return args
 }
 

--- a/internal/common/task_utils.go
+++ b/internal/common/task_utils.go
@@ -114,14 +114,6 @@ func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions
 		args = append(args, "--idle-on-complete", idleOnComplete)
 	}
 
-	// If the server linked this task to an existing AI conversation, forward the id so the
-	// embedded warp CLI can resume that conversation's state (Oz or Claude Code).
-	if task.AgentConversationID != nil {
-		if id := strings.TrimSpace(*task.AgentConversationID); id != "" {
-			args = append(args, "--conversation", id)
-		}
-	}
-
 	return args
 }
 

--- a/internal/common/task_utils_test.go
+++ b/internal/common/task_utils_test.go
@@ -150,11 +150,37 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 			expected: []string{"agent", "run", "--idle-on-complete"},
 		},
 		{
+			name: "appends --conversation when AgentConversationID is set",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+				AgentConversationID: strPtr("abc-123"),
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--idle-on-complete", "--conversation", "abc-123"},
+		},
+		{
+			name: "omits --conversation when AgentConversationID is nil",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--idle-on-complete"},
+		},
+		{
 			name: "skips --share public when public_access is nil",
 			task: &types.Task{
 				AgentConfigSnapshot: &types.AmbientAgentConfig{
 					SessionSharing: &types.SessionSharingConfig{},
 				},
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--idle-on-complete"},
+		},
+		{
+			name: "omits --conversation when AgentConversationID is whitespace-only",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+				AgentConversationID: strPtr("   "),
 			},
 			opts:     TaskAugmentOptions{},
 			expected: []string{"agent", "run", "--idle-on-complete"},

--- a/internal/common/task_utils_test.go
+++ b/internal/common/task_utils_test.go
@@ -150,18 +150,10 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 			expected: []string{"agent", "run", "--idle-on-complete"},
 		},
 		{
-			name: "appends --conversation when AgentConversationID is set",
+			name: "does not forward --conversation even when AgentConversationID is set; the embedded warp CLI reads it off task metadata",
 			task: &types.Task{
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 				AgentConversationID: strPtr("abc-123"),
-			},
-			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete", "--conversation", "abc-123"},
-		},
-		{
-			name: "omits --conversation when AgentConversationID is nil",
-			task: &types.Task{
-				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
 			opts:     TaskAugmentOptions{},
 			expected: []string{"agent", "run", "--idle-on-complete"},
@@ -172,15 +164,6 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				AgentConfigSnapshot: &types.AmbientAgentConfig{
 					SessionSharing: &types.SessionSharingConfig{},
 				},
-			},
-			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
-		},
-		{
-			name: "omits --conversation when AgentConversationID is whitespace-only",
-			task: &types.Task{
-				AgentConfigSnapshot: &types.AmbientAgentConfig{},
-				AgentConversationID: strPtr("   "),
 			},
 			opts:     TaskAugmentOptions{},
 			expected: []string{"agent", "run", "--idle-on-complete"},

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -132,4 +132,8 @@ type Task struct {
 	CreatedAt           time.Time           `json:"created_at"`
 	UpdatedAt           time.Time           `json:"updated_at"`
 	AgentConfigSnapshot *AmbientAgentConfig `json:"agent_config_snapshot,omitempty"`
+	// AgentConversationID is the UUID of an existing AI conversation the server wants the
+	// embedded warp CLI to resume. When set, the worker appends `--conversation <id>` to the
+	// `oz agent run` invocation (see common.AugmentArgsForTask). Nil for fresh runs.
+	AgentConversationID *string `json:"agent_conversation_id,omitempty"`
 }

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -41,8 +41,6 @@ type TaskAssignmentMessage struct {
 	EnvVars map[string]string `json:"env_vars,omitempty"`
 	// AdditionalSidecars is a list of extra sidecar images to mount into the task container.
 	AdditionalSidecars []SidecarMount `json:"additional_sidecars,omitempty"`
-	// ConversationID is the UUID of an existing AI conversation to continue.
-	ConversationID string `json:"conversation_id,omitempty"`
 }
 
 // TaskClaimedMessage is sent from worker to server after successfully claiming a task

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -130,8 +130,5 @@ type Task struct {
 	CreatedAt           time.Time           `json:"created_at"`
 	UpdatedAt           time.Time           `json:"updated_at"`
 	AgentConfigSnapshot *AmbientAgentConfig `json:"agent_config_snapshot,omitempty"`
-	// AgentConversationID is the UUID of an existing AI conversation the server wants the
-	// embedded warp CLI to resume. When set, the worker appends `--conversation <id>` to the
-	// `oz agent run` invocation (see common.AugmentArgsForTask). Nil for fresh runs.
-	AgentConversationID *string `json:"agent_conversation_id,omitempty"`
+	AgentConversationID *string             `json:"agent_conversation_id,omitempty"`
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -375,9 +375,6 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		"--server-root-url",
 		w.config.ServerRootURL,
 	}
-	if assignment.ConversationID != "" {
-		baseArgs = append(baseArgs, "--conversation", assignment.ConversationID)
-	}
 	baseArgs = common.AugmentArgsForTask(task, baseArgs, common.TaskAugmentOptions{
 		IdleOnComplete: w.config.IdleOnComplete,
 	})


### PR DESCRIPTION
WISOTT. this is more in line with how we handle other flags