### PR TITLE
Stamp main.Version into release binaries via -ldflags

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -8,10 +8,20 @@ on:
         required: false
         default: ''
         type: string
+      version:
+        description: 'Build version stamped into the binary via -ldflags="-X main.Version=...". Defaults to docker_tag, then to the commit SHA.'
+        required: false
+        default: ''
+        type: string
   workflow_call:
     inputs:
       docker_tag:
         description: 'Docker image tag (leave empty to skip Docker push)'
+        required: false
+        default: ''
+        type: string
+      version:
+        description: 'Build version stamped into the binary via -ldflags="-X main.Version=...". Defaults to docker_tag, then to the commit SHA.'
         required: false
         default: ''
         type: string
@@ -65,12 +75,15 @@ jobs:
           CGO_ENABLED: '0'
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
+          # Resolve the version stamped into the binary. Precedence:
+          # workflow input `version` > workflow input `docker_tag` > commit SHA.
+          VERSION: ${{ inputs.version != '' && inputs.version || (inputs.docker_tag != '' && inputs.docker_tag || github.sha) }}
         run: |
           binary="oz-agent-worker"
           if [ "$GOOS" = "windows" ]; then
             binary="oz-agent-worker.exe"
           fi
-          go build -o "$binary" .
+          go build -ldflags="-X main.Version=${VERSION}" -o "$binary" .
 
       - name: Archive
         run: |
@@ -120,5 +133,10 @@ jobs:
           outputs: ${{ inputs.docker_tag != '' && 'type=registry' || 'type=local,dest=built-images' }}
           platforms: linux/amd64,linux/arm64
           tags: warpdotdev/oz-agent-worker:${{ inputs.docker_tag || github.sha }}
+          # Forward the resolved version to the Dockerfile so the binary baked
+          # into the image carries the same main.Version as the standalone
+          # release artifacts.
+          build-args: |
+            VERSION=${{ inputs.version != '' && inputs.version || (inputs.docker_tag != '' && inputs.docker_tag || github.sha) }}
           labels:
             dev.warp.worker-commit=${{ github.sha }}

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -20,6 +20,9 @@ jobs:
     secrets: inherit
     with:
       docker_tag: ${{ needs.generate-tag.outputs.tag_name }}
+      # Stamp the same tag into main.Version so `oz_worker_info{version=...}`
+      # in /metrics matches the published release tag and Docker image tag.
+      version: ${{ needs.generate-tag.outputs.tag_name }}
 
   release:
     needs: [generate-tag, build]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,12 @@
 # Build stage
 FROM golang:1.26-alpine AS builder
 
+# VERSION is stamped into the binary via -ldflags="-X main.Version=...".
+# CI passes the release tag (or commit SHA) here so the value reported by
+# `oz_worker_info{version=...}` matches the published Docker tag. Local
+# builds without --build-arg fall back to "dev" to match the source default.
+ARG VERSION=dev
+
 WORKDIR /app
 
 COPY go.mod go.sum ./
@@ -8,7 +14,7 @@ RUN go mod download
 
 COPY . .
 
-RUN CGO_ENABLED=0 GOOS=linux go build -o oz-agent-worker .
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-X main.Version=${VERSION}" -o oz-agent-worker .
 
 # Runtime stage
 FROM alpine:3.22


### PR DESCRIPTION
Adds a shared build-arg/workflow-input plumbed through the existing
release pipeline so `oz_worker_info{version=...}` reports the
published release tag (or commit SHA, for ad-hoc builds) instead of
the source default of "dev":

- build_release.yml: new optional `version` workflow input. The build
  matrix step now passes `-ldflags="-X main.Version=${VERSION}"` with
  precedence `version` input > `docker_tag` input > `github.sha`. The
  same value is forwarded to the Docker build via `--build-arg
  VERSION=...` so the binary baked into the image carries the same
  version string as the standalone release archives.
- create_release.yml: forwards the auto-generated release tag as both
  `docker_tag` and `version`, so a release whose tag is
  `v2026-04-29-16-30-00` exposes that tag at
  `oz_worker_info{version="v2026-04-29-16-30-00"}` and ships in a
  Docker image tagged the same way.
- Dockerfile: declares `ARG VERSION=dev` and threads it into the
  `go build` invocation. Local `docker build` without `--build-arg`
  still produces a "dev" binary, matching the source default.

Verified locally: `go build -ldflags="-X main.Version=test-1.2.3" .`
embeds the value in the binary; running `--help` works and `strings`
confirms the version string is present.

Co-Authored-By: Oz <oz-agent@warp.dev>