### PR TITLE
Add worker extraEnv in the helm chart

### DIFF
--- a/charts/oz-agent-worker/templates/deployment.yaml
+++ b/charts/oz-agent-worker/templates/deployment.yaml
@@ -62,6 +62,9 @@ spec:
                 secretKeyRef:
                   name: {{ include "oz-agent-worker.apiKeySecretName" . }}
                   key: {{ .Values.warp.apiKeySecret.key }}
+            {{- with .Values.worker.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
             {{- if .Values.metrics.enabled }}
             - name: OTEL_METRICS_EXPORTER
               value: {{ .Values.metrics.exporter | quote }}

--- a/charts/oz-agent-worker/values.yaml
+++ b/charts/oz-agent-worker/values.yaml
@@ -32,6 +32,7 @@ worker:
   maxConcurrentTasks: 0
   idleOnComplete: ""
   extraArgs: []
+  extraEnv: []
   deploymentAnnotations: {}
   podAnnotations: {}
   podLabels: {}


### PR DESCRIPTION
Addresses: https://github.com/warpdotdev/oz-agent-worker/issues/60

Some orgs will need to set arbitrary environment variables on the worker (thinking Proxy's etc.) and so exposing a `worker.extraEnv` in the helm chart will allow for this flexibility.