### PR TITLE
fix(k8s): use exec instead of /bin/sh to invoke entrypoint.sh

### DIFF
--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -1043,7 +1043,7 @@ func kubernetesTaskWrapperScript() string {
 		"  . \"$OZ_ENVIRONMENT_FILE\"",
 		"  set +a",
 		"fi",
-		"/bin/sh /agent/entrypoint.sh \"$@\"",
+		"exec /agent/entrypoint.sh \"$@\"",
 	}, "\n")
 }
 


### PR DESCRIPTION
https://warpdev.slack.com/archives/C09E37H1NMA/p1777818114403259 - context