### PR TITLE
fix: conditionally set --share team:edit based on task ownership

### DIFF
--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -122,6 +122,18 @@ type AmbientAgentConfig struct {
 	SnapshotScriptTimeoutSecs *int                       `json:"snapshot_script_timeout_secs,omitempty"`
 }
 
+// TaskOwner identifies the ownership scope of a task.
+// Matches the server's PermissionSubjectAndID serialization.
+type TaskOwner struct {
+	Type string `json:"Type"` // "USER" or "TEAM"
+	Id   int    `json:"Id"`
+}
+
+// IsTeamOwned returns true when the task owner is a team.
+func (o *TaskOwner) IsTeamOwned() bool {
+	return o != nil && o.Type == "TEAM"
+}
+
 // Task represents an ambient agent job.
 type Task struct {
 	ID                  string              `json:"id"`
@@ -129,6 +141,7 @@ type Task struct {
 	Definition          TaskDefinition      `json:"task_definition"`
 	CreatedAt           time.Time           `json:"created_at"`
 	UpdatedAt           time.Time           `json:"updated_at"`
+	Owner               *TaskOwner          `json:"owner,omitempty"`
 	AgentConfigSnapshot *AmbientAgentConfig `json:"agent_config_snapshot,omitempty"`
 	AgentConversationID *string             `json:"agent_conversation_id,omitempty"`
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -392,14 +392,20 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 	baseArgs := []string{
 		"agent",
 		"run",
-		"--share",
-		"team:edit",
+	}
+	// Only share with the team when the task is team-owned. User-owned tasks
+	// (created with "Team visible" unchecked) use user-scoped API keys that
+	// cannot set up team-level session sharing.
+	if task.Owner.IsTeamOwned() {
+		baseArgs = append(baseArgs, "--share", "team:edit")
+	}
+	baseArgs = append(baseArgs,
 		"--task-id",
 		task.ID,
 		"--sandboxed",
 		"--server-root-url",
 		w.config.ServerRootURL,
-	}
+	)
 	baseArgs = common.AugmentArgsForTask(task, baseArgs, common.TaskAugmentOptions{
 		IdleOnComplete: w.config.IdleOnComplete,
 	})

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -295,6 +295,68 @@ func TestPrepareTaskParamsSidecarImageOverride(t *testing.T) {
 	})
 }
 
+func TestPrepareTaskParamsTeamShareConditional(t *testing.T) {
+	newWorker := func() *Worker {
+		return &Worker{
+			ctx: context.Background(),
+			config: Config{
+				ServerRootURL: "https://app.warp.dev",
+				Kubernetes:    &KubernetesBackendConfig{},
+			},
+		}
+	}
+
+	containsShareTeamEdit := func(args []string) bool {
+		for i, arg := range args {
+			if arg == "--share" && i+1 < len(args) && args[i+1] == "team:edit" {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("includes --share team:edit for team-owned task", func(t *testing.T) {
+		w := newWorker()
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID: "task-1",
+			Task: &types.Task{
+				ID:    "task-1",
+				Owner: &types.TaskOwner{Type: "TEAM", Id: 42},
+			},
+		})
+		if !containsShareTeamEdit(params.BaseArgs) {
+			t.Fatalf("expected --share team:edit in args for team-owned task, got %v", params.BaseArgs)
+		}
+	})
+
+	t.Run("omits --share team:edit for user-owned task", func(t *testing.T) {
+		w := newWorker()
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID: "task-2",
+			Task: &types.Task{
+				ID:    "task-2",
+				Owner: &types.TaskOwner{Type: "USER", Id: 99},
+			},
+		})
+		if containsShareTeamEdit(params.BaseArgs) {
+			t.Fatalf("did not expect --share team:edit in args for user-owned task, got %v", params.BaseArgs)
+		}
+	})
+
+	t.Run("omits --share team:edit when owner is nil", func(t *testing.T) {
+		w := newWorker()
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID: "task-3",
+			Task: &types.Task{
+				ID: "task-3",
+			},
+		})
+		if containsShareTeamEdit(params.BaseArgs) {
+			t.Fatalf("did not expect --share team:edit in args when owner is nil, got %v", params.BaseArgs)
+		}
+	})
+}
+
 func TestWorkerShutdownUsesFreshContextForBackendCleanup(t *testing.T) {
 	workerCtx, cancel := context.WithCancel(context.Background())
 	backend := &shutdownRecordingBackend{}


### PR DESCRIPTION
## Problem

When "Team visible" is unchecked in the Oz web app, self-hosted worker agents
fail to start every time. This is a 100% repro on the K8s backend.

### Root Cause

The `oz-agent-worker` hardcodes `--share team:edit` in the CLI args for every
task (`worker.go:395`). When "Team visible" is unchecked:

1. The server creates the task with `UserPermissionSubject` ownership
2. `GenerateAPIKeyForTask` produces a user-scoped per-task API key
3. The oz CLI authenticates with this user-scoped key and tries to set up
   team-level session sharing via `--share team:edit`
4. This fails because the user-scoped key cannot create team-scoped sessions

## Solution

- Add a `TaskOwner` type to the worker's `Task` struct to deserialize the
  `owner` field the server already sends in the `TaskAssignmentMessage`
- Conditionally emit `--share team:edit` only when `owner.Type == "TEAM"`
- User-owned tasks skip team sharing, letting the session stay user-scoped

No server-side changes needed — the server already serializes `Task.Owner`
in the WebSocket assignment payload.

## Testing

- Added unit tests for team-owned, user-owned, and nil-owner cases
- All existing tests pass (`go test ./...`)

---

_Conversation: https://staging.warp.dev/conversation/5d0d24f7-28ac-4621-9f24-e337039d989a_
_Run: https://oz.staging.warp.dev/runs/019dfa3a-1ee9-7d99-8eb8-f1c1081a10a9_
_This PR was generated with [Oz](https://warp.dev/oz)._
