### PR TITLE
Add harness environment variables to self-hosted worker with direct backend

### DIFF
--- a/internal/worker/direct.go
+++ b/internal/worker/direct.go
@@ -140,6 +140,7 @@ func (b *DirectBackend) ExecuteTask(ctx context.Context, params *TaskParams) err
 	for key, value := range b.config.Env {
 		envVars = append(envVars, fmt.Sprintf("%s=%s", key, value))
 	}
+	envVars = mergeEnvVars(envVars, harnessEnvVars(workspaceDir, params))
 
 	// 4. Run setup command if configured.
 	if b.config.SetupCommand != "" {
@@ -281,4 +282,39 @@ func mergeEnvVars(base, override []string) []string {
 // It supports quoted values, comments, and other standard dotenv syntax via godotenv.
 func parseEnvFile(path string) (map[string]string, error) {
 	return godotenv.Read(path)
+}
+
+type harnessConfig struct {
+	configEnvVar string
+	configDir    string
+}
+
+// Used for setting configEnvVar to "workspaceDir/configDir"
+var harnessConfigs = map[string]harnessConfig{
+	"claude": {
+		configEnvVar: "CLAUDE_CONFIG_DIR",
+		configDir:    ".claude",
+	},
+	"codex": {
+		configEnvVar: "CODEX_HOME",
+		configDir:    ".codex",
+	},
+}
+
+// When running with a third-party harness, set state environment variables so that the harness
+// state will be written to the workspace dir rather than globally. This helps us keep concurrent tasks
+// from interfering with one another.
+func harnessEnvVars(workspaceDir string, params *TaskParams) []string {
+	if params == nil ||
+		params.Task == nil ||
+		params.Task.AgentConfigSnapshot == nil ||
+		params.Task.AgentConfigSnapshot.Harness == nil ||
+		params.Task.AgentConfigSnapshot.Harness.Type == nil {
+		return nil
+	}
+	config, ok := harnessConfigs[strings.TrimSpace(*params.Task.AgentConfigSnapshot.Harness.Type)]
+	if !ok {
+		return nil
+	}
+	return []string{fmt.Sprintf("%s=%s", config.configEnvVar, filepath.Join(workspaceDir, config.configDir))}
 }

--- a/internal/worker/direct_test.go
+++ b/internal/worker/direct_test.go
@@ -1,0 +1,76 @@
+package worker
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/warpdotdev/oz-agent-worker/internal/types"
+)
+
+func TestDirectHarnessEnv(t *testing.T) {
+	workspaceDir := filepath.Join(string(filepath.Separator), "tmp", "workspace")
+
+	tests := []struct {
+		name    string
+		harness *string
+		want    map[string]string
+	}{
+		{
+			name:    "claude",
+			harness: stringPtr("claude"),
+			want: map[string]string{
+				"CLAUDE_CONFIG_DIR": filepath.Join(workspaceDir, ".claude"),
+			},
+		},
+		{
+			name:    "codex",
+			harness: stringPtr("codex"),
+			want: map[string]string{
+				"CODEX_HOME": filepath.Join(workspaceDir, ".codex"),
+			},
+		},
+		{
+			name:    "unknown",
+			harness: stringPtr("other"),
+			want:    map[string]string{},
+		},
+		{
+			name:    "missing",
+			harness: nil,
+			want:    map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := &TaskParams{Task: &types.Task{AgentConfigSnapshot: &types.AmbientAgentConfig{}}}
+			if tt.harness != nil {
+				params.Task.AgentConfigSnapshot.Harness = &types.Harness{Type: tt.harness}
+			}
+
+			got := envMap(harnessEnvVars(workspaceDir, params))
+			if len(got) != len(tt.want) {
+				t.Fatalf("env count = %d, want %d: %#v", len(got), len(tt.want), got)
+			}
+			for key, want := range tt.want {
+				if got[key] != want {
+					t.Fatalf("%s = %q, want %q", key, got[key], want)
+				}
+			}
+		})
+	}
+}
+
+func stringPtr(value string) *string {
+	return &value
+}
+
+func envMap(values []string) map[string]string {
+	result := make(map[string]string, len(values))
+	for _, value := range values {
+		key, val, _ := strings.Cut(value, "=")
+		result[key] = val
+	}
+	return result
+}


### PR DESCRIPTION
## Description
This PR sets the `CLAUDE_CONFIG_DIR` and `CODEX_HOME` environment variables for the self-hosted worker with direct backend to be `workspaceDir/.claude` and `workspaceDir/.codex` respectively on a per-task basis.

Since we don't have filesystem isolation for the direct backend worker, we want to be able to set harness config on a per-task basis, and cannot rely on the default claude/codex config directories (otherwise, concurrent tasks would clobber each other, we wouldn't clean up their state when done, etc.).

The client-side support for these environment variables is implemented in https://github.com/warpdotdev/warp/pull/10870.

## Testing
Ran the `oz-local` script with my self-hosted direct backend worker, nuked my global claude config at `~/.claude`, and verified that the agent was able to run to completion anyways. Confirmed that the config files _were_ written to `workspaceDir/.claude`.
