### PR TITLE
Forward Bedrock STS region via --bedrock-role-region

### DIFF
--- a/internal/common/task_utils.go
+++ b/internal/common/task_utils.go
@@ -59,9 +59,15 @@ func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions
 			}
 		}
 
+		// Forward the AWS Bedrock OIDC role ARN, if any. When a region is also
+		// configured, pair it with --bedrock-role-region so the Warp client's
+		// STS AssumeRoleWithWebIdentity call targets the right regional endpoint.
 		if aws := task.AgentConfigSnapshot.InferenceProviders; aws != nil && aws.Aws != nil && !aws.Aws.Disabled {
 			if role := strings.TrimSpace(aws.Aws.RoleARN); role != "" {
 				args = append(args, "--bedrock-inference-role", role)
+				if region := strings.TrimSpace(aws.Aws.Region); region != "" {
+					args = append(args, "--bedrock-role-region", region)
+				}
 			}
 		}
 

--- a/internal/common/task_utils_test.go
+++ b/internal/common/task_utils_test.go
@@ -112,6 +112,50 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 			},
 		},
 		{
+			name: "pairs --bedrock-role-region with --bedrock-inference-role when region is set",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					InferenceProviders: &types.InferenceProviders{
+						Aws: &types.AwsInferenceProvider{
+							RoleARN: "arn:aws:iam::123456789012:role/BedrockInference",
+							Region:  "  us-east-1  ",
+						},
+					},
+				},
+			},
+			opts: TaskAugmentOptions{},
+			expected: []string{
+				"agent",
+				"run",
+				"--bedrock-inference-role",
+				"arn:aws:iam::123456789012:role/BedrockInference",
+				"--bedrock-role-region",
+				"us-east-1",
+				"--idle-on-complete",
+			},
+		},
+		{
+			name: "omits --bedrock-role-region when region is whitespace",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					InferenceProviders: &types.InferenceProviders{
+						Aws: &types.AwsInferenceProvider{
+							RoleARN: "arn:aws:iam::123456789012:role/BedrockInference",
+							Region:  "   ",
+						},
+					},
+				},
+			},
+			opts: TaskAugmentOptions{},
+			expected: []string{
+				"agent",
+				"run",
+				"--bedrock-inference-role",
+				"arn:aws:iam::123456789012:role/BedrockInference",
+				"--idle-on-complete",
+			},
+		},
+		{
 			name: "skips --bedrock-inference-role when role_arn is whitespace",
 			task: &types.Task{
 				AgentConfigSnapshot: &types.AmbientAgentConfig{

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -141,10 +141,13 @@ type InferenceProviders struct {
 
 // AwsInferenceProvider mirrors warp-server's snapshot-local representation of
 // the AWS Bedrock block. When Disabled is false and RoleARN is non-empty, the
-// worker forwards the role to the Warp client as --bedrock-inference-role.
+// worker forwards the role to the Warp client as --bedrock-inference-role and,
+// when Region is set, pairs it with --bedrock-role-region so the STS
+// AssumeRoleWithWebIdentity call targets the right regional endpoint.
 type AwsInferenceProvider struct {
 	Disabled bool   `json:"disabled,omitempty"`
 	RoleARN  string `json:"role_arn,omitempty"`
+	Region   string `json:"region,omitempty"`
 }
 
 // Task represents an ambient agent job.


### PR DESCRIPTION

pr 1/2 that addresses convo here: https://github.com/warpdotdev/warp-server/pull/11178#discussion_r3251382454

## Desc

Setting `AWS_REGION` on the task container was leaking the region into every sub-process inside the run. Switch to a hidden `--bedrock-role-region` CLI flag (paired with `--bedrock-inference-role`) so only the Warp client uses the region when minting OIDC-managed Bedrock credentials via STS `AssumeRoleWithWebIdentity`.

## Changes

- `internal/types/messages.go`: add `Region` to `AwsInferenceProvider` so the snapshot from warp-server can carry it alongside the role ARN.
- `internal/common/task_utils.go`: in `AugmentArgsForTask`, when the AWS provider is enabled and a role ARN is present, also emit `--bedrock-role-region <region>` when a region is configured.
- `internal/common/task_utils_test.go`: cover the role+region pairing and the whitespace-only region case.

Pairs with:
- warp-server: removes the `AWS_REGION` env var emission and emits `--bedrock-role-region` from `AugmentArgsForTask` (branch `iw/add-aws-region-to-oz-runs`).
- warp-2: adds the hidden `--bedrock-role-region` CLI flag and threads it into the STS client used for OIDC-managed Bedrock credentials.

## Test plan

- `go build ./...`
- `go test ./...`
- `go vet ./...`

Draft until the warp-2 client side is up.

[Warp conversation](https://staging.warp.dev/conversation/04e2b49f-73e6-4fe9-b827-078e2a0397e9)

Co-Authored-By: Oz <oz-agent@warp.dev>