### PR TITLE
Derive --skip-initial-turn from per-execution input at the worker

### DIFF
--- a/internal/common/task_utils.go
+++ b/internal/common/task_utils.go
@@ -8,22 +8,23 @@ import (
 	"github.com/warpdotdev/oz-agent-worker/internal/types"
 )
 
-// TaskAugmentOptions contains worker-level settings that are translated into oz CLI flags
-// for every task. Add new per-worker CLI overrides here rather than as extra parameters.
+// TaskAugmentOptions contains settings translated into oz CLI flags for every task.
+// Add new CLI overrides here rather than as extra parameters.
 type TaskAugmentOptions struct {
 	// IdleOnComplete is passed to --idle-on-complete. Empty string uses the oz CLI default
 	// (45m). Use "0s" to exit immediately after the conversation finishes.
 	// Task-level config.idle_timeout_minutes takes precedence when set.
 	IdleOnComplete string
+	// SkipInitialTurn is the server-computed decision (warp-server-4's
+	// ShouldSkipInitialTurn helper is the single authority) that controls
+	// whether the worker emits --skip-initial-turn to the CLI. The worker is a
+	// passthrough; it does not re-derive the decision.
+	SkipInitialTurn bool
 }
 
 // AugmentArgsForTask allows different task sources to add CLI args in a centralized place.
 // Uses task.AgentConfigSnapshot as the source of truth when available.
-//
-// skipInitialTurn is the server-computed decision (warp-server-4's
-// shouldSkipInitialTurn helper is the single authority) that controls whether
-// the worker emits --skip-initial-turn to the CLI. The worker is a passthrough.
-func AugmentArgsForTask(task *types.Task, skipInitialTurn bool, args []string, opts TaskAugmentOptions) []string {
+func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions) []string {
 	if task == nil {
 		return args
 	}
@@ -116,10 +117,10 @@ func AugmentArgsForTask(task *types.Task, skipInitialTurn bool, args []string, o
 	}
 
 	// Server-computed: skip the cloud agent's initial LLM turn. The decision
-	// lives in warp-server-4's shouldSkipInitialTurn helper so future content
+	// lives in warp-server-4's ShouldSkipInitialTurn helper so future content
 	// sources (e.g. orchestration system prompts) can be enumerated server-side
 	// without touching the worker.
-	if skipInitialTurn {
+	if opts.SkipInitialTurn {
 		args = append(args, "--skip-initial-turn")
 	}
 

--- a/internal/common/task_utils.go
+++ b/internal/common/task_utils.go
@@ -15,11 +15,8 @@ type TaskAugmentOptions struct {
 	// (45m). Use "0s" to exit immediately after the conversation finishes.
 	// Task-level config.idle_timeout_minutes takes precedence when set.
 	IdleOnComplete string
-	// SkipInitialTurn is the server-computed decision (warp-server-4's
-	// ShouldSkipInitialTurn helper is the single authority) that controls
-	// whether the worker emits --skip-initial-turn to the CLI. The worker is a
-	// passthrough; it does not re-derive the decision.
-	SkipInitialTurn bool
+	// AdditionalOzArgs are server-resolved supplemental oz CLI arguments.
+	AdditionalOzArgs []string
 }
 
 // AugmentArgsForTask allows different task sources to add CLI args in a centralized place.
@@ -116,13 +113,7 @@ func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions
 		}
 	}
 
-	// Server-computed: skip the cloud agent's initial LLM turn. The decision
-	// lives in warp-server-4's ShouldSkipInitialTurn helper so future content
-	// sources (e.g. orchestration system prompts) can be enumerated server-side
-	// without touching the worker.
-	if opts.SkipInitialTurn {
-		args = append(args, "--skip-initial-turn")
-	}
+	args = append(args, opts.AdditionalOzArgs...)
 
 	// Keep the agent alive after task completion to allow follow-ups.
 	// Priority: task config idle_timeout_minutes > worker IdleOnComplete > oz CLI default (45m).

--- a/internal/common/task_utils.go
+++ b/internal/common/task_utils.go
@@ -19,7 +19,12 @@ type TaskAugmentOptions struct {
 
 // AugmentArgsForTask allows different task sources to add CLI args in a centralized place.
 // Uses task.AgentConfigSnapshot as the source of truth when available.
-func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions) []string {
+//
+// executionInput carries the per-execution inputs (prompt + initial snapshot token)
+// the worker uses to derive per-execution CLI behavior such as --skip-initial-turn.
+// It is derived fresh per execution so cloud->cloud follow-ups cannot inherit a
+// stale decision from a prior execution on the same task.
+func AugmentArgsForTask(task *types.Task, executionInput *types.WorkerExecutionInput, args []string, opts TaskAugmentOptions) []string {
 	if task == nil {
 		return args
 	}
@@ -111,6 +116,14 @@ func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions
 		}
 	}
 
+	// Worker-derived: skip the cloud agent's initial LLM turn when this
+	// execution has no prompt and no snapshot to rehydrate against. Derived
+	// fresh per execution so a cloud->cloud follow-up with a real prompt
+	// does not inherit the skip decision from a prior empty-prompt execution.
+	if shouldSkipInitialTurn(executionInput) {
+		args = append(args, "--skip-initial-turn")
+	}
+
 	// Keep the agent alive after task completion to allow follow-ups.
 	// Priority: task config idle_timeout_minutes > worker IdleOnComplete > oz CLI default (45m).
 	idleOnComplete, hasIdleOnCompleteValue := resolveIdleOnComplete(task, opts)
@@ -121,6 +134,23 @@ func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions
 	}
 
 	return args
+}
+
+// shouldSkipInitialTurn returns true when this execution has nothing for the
+// cloud agent's first LLM turn to act on: an empty prompt AND no initial
+// snapshot to rehydrate. Mirrors warp-server-4's derivation helper so both
+// sides of the worker pipeline make the same decision.
+func shouldSkipInitialTurn(executionInput *types.WorkerExecutionInput) bool {
+	if executionInput == nil {
+		return false
+	}
+	if executionInput.Prompt != "" {
+		return false
+	}
+	if executionInput.InitialSnapshotToken != nil && *executionInput.InitialSnapshotToken != "" {
+		return false
+	}
+	return true
 }
 
 // shareAccessLevelForEmission maps an internal AccessLevel to the string

--- a/internal/common/task_utils.go
+++ b/internal/common/task_utils.go
@@ -20,11 +20,10 @@ type TaskAugmentOptions struct {
 // AugmentArgsForTask allows different task sources to add CLI args in a centralized place.
 // Uses task.AgentConfigSnapshot as the source of truth when available.
 //
-// executionInput carries the per-execution inputs (prompt + initial snapshot token)
-// the worker uses to derive per-execution CLI behavior such as --skip-initial-turn.
-// It is derived fresh per execution so cloud->cloud follow-ups cannot inherit a
-// stale decision from a prior execution on the same task.
-func AugmentArgsForTask(task *types.Task, executionInput *types.WorkerExecutionInput, args []string, opts TaskAugmentOptions) []string {
+// skipInitialTurn is the server-computed decision (warp-server-4's
+// shouldSkipInitialTurn helper is the single authority) that controls whether
+// the worker emits --skip-initial-turn to the CLI. The worker is a passthrough.
+func AugmentArgsForTask(task *types.Task, skipInitialTurn bool, args []string, opts TaskAugmentOptions) []string {
 	if task == nil {
 		return args
 	}
@@ -116,11 +115,11 @@ func AugmentArgsForTask(task *types.Task, executionInput *types.WorkerExecutionI
 		}
 	}
 
-	// Worker-derived: skip the cloud agent's initial LLM turn when this
-	// execution has no prompt and no snapshot to rehydrate against. Derived
-	// fresh per execution so a cloud->cloud follow-up with a real prompt
-	// does not inherit the skip decision from a prior empty-prompt execution.
-	if shouldSkipInitialTurn(executionInput) {
+	// Server-computed: skip the cloud agent's initial LLM turn. The decision
+	// lives in warp-server-4's shouldSkipInitialTurn helper so future content
+	// sources (e.g. orchestration system prompts) can be enumerated server-side
+	// without touching the worker.
+	if skipInitialTurn {
 		args = append(args, "--skip-initial-turn")
 	}
 
@@ -134,23 +133,6 @@ func AugmentArgsForTask(task *types.Task, executionInput *types.WorkerExecutionI
 	}
 
 	return args
-}
-
-// shouldSkipInitialTurn returns true when this execution has nothing for the
-// cloud agent's first LLM turn to act on: an empty prompt AND no initial
-// snapshot to rehydrate. Mirrors warp-server-4's derivation helper so both
-// sides of the worker pipeline make the same decision.
-func shouldSkipInitialTurn(executionInput *types.WorkerExecutionInput) bool {
-	if executionInput == nil {
-		return false
-	}
-	if executionInput.Prompt != "" {
-		return false
-	}
-	if executionInput.InitialSnapshotToken != nil && *executionInput.InitialSnapshotToken != "" {
-		return false
-	}
-	return true
 }
 
 // shareAccessLevelForEmission maps an internal AccessLevel to the string

--- a/internal/common/task_utils_test.go
+++ b/internal/common/task_utils_test.go
@@ -264,18 +264,15 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 			},
 		},
 		{
-			// Worker is a passthrough: when the server-computed SkipInitialTurn
-			// option is true, emit --skip-initial-turn. The derivation logic
-			// lives in warp-server-4's ShouldSkipInitialTurn, not here.
-			name: "emits --skip-initial-turn when opts.SkipInitialTurn is true",
+			name: "appends supplemental oz args before idle timeout",
 			task: &types.Task{
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
-			opts:     TaskAugmentOptions{SkipInitialTurn: true},
+			opts:     TaskAugmentOptions{AdditionalOzArgs: []string{"--skip-initial-turn"}},
 			expected: []string{"agent", "run", "--skip-initial-turn", "--idle-on-complete"},
 		},
 		{
-			name: "does not emit --skip-initial-turn when opts.SkipInitialTurn is false",
+			name: "does not emit supplemental oz args when none are provided",
 			task: &types.Task{
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},

--- a/internal/common/task_utils_test.go
+++ b/internal/common/task_utils_test.go
@@ -16,11 +16,11 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 	baseArgs := []string{"agent", "run"}
 
 	tests := []struct {
-		name           string
-		task           *types.Task
-		executionInput *types.WorkerExecutionInput
-		opts           TaskAugmentOptions
-		expected       []string
+		name            string
+		task            *types.Task
+		skipInitialTurn bool
+		opts            TaskAugmentOptions
+		expected        []string
 	}{
 		{
 			name: "uses task idle_timeout_minutes when set",
@@ -265,84 +265,31 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 			},
 		},
 		{
-			name: "emits --skip-initial-turn when execution prompt is empty and no snapshot token",
+			// Worker is a passthrough: when the server-computed SkipInitialTurn
+			// is true, emit --skip-initial-turn. The derivation logic lives in
+			// warp-server-4's shouldSkipInitialTurn, not here.
+			name: "emits --skip-initial-turn when skipInitialTurn is true",
 			task: &types.Task{
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
-			executionInput: &types.WorkerExecutionInput{
-				Prompt:               "",
-				InitialSnapshotToken: nil,
-			},
-			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--skip-initial-turn", "--idle-on-complete"},
+			skipInitialTurn: true,
+			opts:            TaskAugmentOptions{},
+			expected:        []string{"agent", "run", "--skip-initial-turn", "--idle-on-complete"},
 		},
 		{
-			name: "does not emit --skip-initial-turn when execution prompt is empty but snapshot token is set",
+			name: "does not emit --skip-initial-turn when skipInitialTurn is false",
 			task: &types.Task{
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
-			executionInput: &types.WorkerExecutionInput{
-				Prompt:               "",
-				InitialSnapshotToken: strPtr("snap-token-abc"),
-			},
-			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
-		},
-		{
-			name: "does not emit --skip-initial-turn when execution prompt is non-empty",
-			task: &types.Task{
-				AgentConfigSnapshot: &types.AmbientAgentConfig{},
-			},
-			executionInput: &types.WorkerExecutionInput{
-				Prompt:               "do the thing",
-				InitialSnapshotToken: nil,
-			},
-			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
-		},
-		{
-			// Cloud->cloud-follow-up regression: same task, follow-up execution
-			// arrives with a real prompt. The derivation must reflect the live
-			// execution, not any flag the original empty-prompt execution may have
-			// carried. Worker derives fresh per execution, so the follow-up never
-			// emits --skip-initial-turn even though the first execution would have.
-			name: "cloud->cloud follow-up: follow-up execution with prompt does not emit --skip-initial-turn",
-			task: &types.Task{
-				AgentConfigSnapshot: &types.AmbientAgentConfig{},
-			},
-			executionInput: &types.WorkerExecutionInput{
-				Prompt:               "follow up question",
-				InitialSnapshotToken: nil,
-			},
-			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
-		},
-		{
-			name: "does not emit --skip-initial-turn when execution input is nil",
-			task: &types.Task{
-				AgentConfigSnapshot: &types.AmbientAgentConfig{},
-			},
-			executionInput: nil,
-			opts:           TaskAugmentOptions{},
-			expected:       []string{"agent", "run", "--idle-on-complete"},
-		},
-		{
-			name: "treats empty-string snapshot token the same as nil",
-			task: &types.Task{
-				AgentConfigSnapshot: &types.AmbientAgentConfig{},
-			},
-			executionInput: &types.WorkerExecutionInput{
-				Prompt:               "",
-				InitialSnapshotToken: strPtr(""),
-			},
-			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--skip-initial-turn", "--idle-on-complete"},
+			skipInitialTurn: false,
+			opts:            TaskAugmentOptions{},
+			expected:        []string{"agent", "run", "--idle-on-complete"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := AugmentArgsForTask(tt.task, tt.executionInput, append([]string{}, baseArgs...), tt.opts)
+			got := AugmentArgsForTask(tt.task, tt.skipInitialTurn, append([]string{}, baseArgs...), tt.opts)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Fatalf("args mismatch\n got: %#v\nwant: %#v", got, tt.expected)
 			}

--- a/internal/common/task_utils_test.go
+++ b/internal/common/task_utils_test.go
@@ -16,10 +16,11 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 	baseArgs := []string{"agent", "run"}
 
 	tests := []struct {
-		name     string
-		task     *types.Task
-		opts     TaskAugmentOptions
-		expected []string
+		name           string
+		task           *types.Task
+		executionInput *types.WorkerExecutionInput
+		opts           TaskAugmentOptions
+		expected       []string
 	}{
 		{
 			name: "uses task idle_timeout_minutes when set",
@@ -263,11 +264,85 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				"--idle-on-complete",
 			},
 		},
+		{
+			name: "emits --skip-initial-turn when execution prompt is empty and no snapshot token",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+			},
+			executionInput: &types.WorkerExecutionInput{
+				Prompt:               "",
+				InitialSnapshotToken: nil,
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--skip-initial-turn", "--idle-on-complete"},
+		},
+		{
+			name: "does not emit --skip-initial-turn when execution prompt is empty but snapshot token is set",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+			},
+			executionInput: &types.WorkerExecutionInput{
+				Prompt:               "",
+				InitialSnapshotToken: strPtr("snap-token-abc"),
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--idle-on-complete"},
+		},
+		{
+			name: "does not emit --skip-initial-turn when execution prompt is non-empty",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+			},
+			executionInput: &types.WorkerExecutionInput{
+				Prompt:               "do the thing",
+				InitialSnapshotToken: nil,
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--idle-on-complete"},
+		},
+		{
+			// Cloud->cloud-follow-up regression: same task, follow-up execution
+			// arrives with a real prompt. The derivation must reflect the live
+			// execution, not any flag the original empty-prompt execution may have
+			// carried. Worker derives fresh per execution, so the follow-up never
+			// emits --skip-initial-turn even though the first execution would have.
+			name: "cloud->cloud follow-up: follow-up execution with prompt does not emit --skip-initial-turn",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+			},
+			executionInput: &types.WorkerExecutionInput{
+				Prompt:               "follow up question",
+				InitialSnapshotToken: nil,
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--idle-on-complete"},
+		},
+		{
+			name: "does not emit --skip-initial-turn when execution input is nil",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+			},
+			executionInput: nil,
+			opts:           TaskAugmentOptions{},
+			expected:       []string{"agent", "run", "--idle-on-complete"},
+		},
+		{
+			name: "treats empty-string snapshot token the same as nil",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+			},
+			executionInput: &types.WorkerExecutionInput{
+				Prompt:               "",
+				InitialSnapshotToken: strPtr(""),
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--skip-initial-turn", "--idle-on-complete"},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := AugmentArgsForTask(tt.task, append([]string{}, baseArgs...), tt.opts)
+			got := AugmentArgsForTask(tt.task, tt.executionInput, append([]string{}, baseArgs...), tt.opts)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Fatalf("args mismatch\n got: %#v\nwant: %#v", got, tt.expected)
 			}

--- a/internal/common/task_utils_test.go
+++ b/internal/common/task_utils_test.go
@@ -16,11 +16,10 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 	baseArgs := []string{"agent", "run"}
 
 	tests := []struct {
-		name            string
-		task            *types.Task
-		skipInitialTurn bool
-		opts            TaskAugmentOptions
-		expected        []string
+		name     string
+		task     *types.Task
+		opts     TaskAugmentOptions
+		expected []string
 	}{
 		{
 			name: "uses task idle_timeout_minutes when set",
@@ -266,30 +265,28 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 		},
 		{
 			// Worker is a passthrough: when the server-computed SkipInitialTurn
-			// is true, emit --skip-initial-turn. The derivation logic lives in
-			// warp-server-4's shouldSkipInitialTurn, not here.
-			name: "emits --skip-initial-turn when skipInitialTurn is true",
+			// option is true, emit --skip-initial-turn. The derivation logic
+			// lives in warp-server-4's ShouldSkipInitialTurn, not here.
+			name: "emits --skip-initial-turn when opts.SkipInitialTurn is true",
 			task: &types.Task{
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
-			skipInitialTurn: true,
-			opts:            TaskAugmentOptions{},
-			expected:        []string{"agent", "run", "--skip-initial-turn", "--idle-on-complete"},
+			opts:     TaskAugmentOptions{SkipInitialTurn: true},
+			expected: []string{"agent", "run", "--skip-initial-turn", "--idle-on-complete"},
 		},
 		{
-			name: "does not emit --skip-initial-turn when skipInitialTurn is false",
+			name: "does not emit --skip-initial-turn when opts.SkipInitialTurn is false",
 			task: &types.Task{
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
-			skipInitialTurn: false,
-			opts:            TaskAugmentOptions{},
-			expected:        []string{"agent", "run", "--idle-on-complete"},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--idle-on-complete"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := AugmentArgsForTask(tt.task, tt.skipInitialTurn, append([]string{}, baseArgs...), tt.opts)
+			got := AugmentArgsForTask(tt.task, append([]string{}, baseArgs...), tt.opts)
 			if !reflect.DeepEqual(got, tt.expected) {
 				t.Fatalf("args mismatch\n got: %#v\nwant: %#v", got, tt.expected)
 			}

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -30,6 +30,16 @@ type SidecarMount struct {
 	ReadWrite bool   `json:"read_write"` // If false (default), the mount is read-only.
 }
 
+// WorkerExecutionInput carries the per-execution inputs the worker needs to derive
+// per-execution CLI behavior (e.g. whether to skip the cloud agent's initial LLM
+// turn). Mirrors the wire shape on warp-server-4's TaskAssignmentMessage so the
+// derivation is computed fresh from the live execution rather than from a stored
+// task-config flag, which would drift on cloud->cloud follow-ups.
+type WorkerExecutionInput struct {
+	Prompt               string  `json:"prompt"`
+	InitialSnapshotToken *string `json:"initial_snapshot_token,omitempty"`
+}
+
 // TaskAssignmentMessage is sent from server to worker when a task is available
 type TaskAssignmentMessage struct {
 	TaskID      string `json:"task_id"`
@@ -41,6 +51,10 @@ type TaskAssignmentMessage struct {
 	EnvVars map[string]string `json:"env_vars,omitempty"`
 	// AdditionalSidecars is a list of extra sidecar images to mount into the task container.
 	AdditionalSidecars []SidecarMount `json:"additional_sidecars,omitempty"`
+	// ExecutionInput carries the per-execution inputs the worker uses to derive
+	// per-execution CLI behavior. Nil for legacy senders or messages that
+	// haven't been upgraded yet.
+	ExecutionInput *WorkerExecutionInput `json:"execution_input,omitempty"`
 }
 
 // TaskClaimedMessage is sent from worker to server after successfully claiming a task

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -30,16 +30,6 @@ type SidecarMount struct {
 	ReadWrite bool   `json:"read_write"` // If false (default), the mount is read-only.
 }
 
-// WorkerExecutionInput carries the per-execution inputs the worker needs to derive
-// per-execution CLI behavior (e.g. whether to skip the cloud agent's initial LLM
-// turn). Mirrors the wire shape on warp-server-4's TaskAssignmentMessage so the
-// derivation is computed fresh from the live execution rather than from a stored
-// task-config flag, which would drift on cloud->cloud follow-ups.
-type WorkerExecutionInput struct {
-	Prompt               string  `json:"prompt"`
-	InitialSnapshotToken *string `json:"initial_snapshot_token,omitempty"`
-}
-
 // TaskAssignmentMessage is sent from server to worker when a task is available
 type TaskAssignmentMessage struct {
 	TaskID      string `json:"task_id"`
@@ -51,10 +41,11 @@ type TaskAssignmentMessage struct {
 	EnvVars map[string]string `json:"env_vars,omitempty"`
 	// AdditionalSidecars is a list of extra sidecar images to mount into the task container.
 	AdditionalSidecars []SidecarMount `json:"additional_sidecars,omitempty"`
-	// ExecutionInput carries the per-execution inputs the worker uses to derive
-	// per-execution CLI behavior. Nil for legacy senders or messages that
-	// haven't been upgraded yet.
-	ExecutionInput *WorkerExecutionInput `json:"execution_input,omitempty"`
+	// SkipInitialTurn mirrors the warp-server-4 wire shape: the server's
+	// shouldSkipInitialTurn helper is the single authority for the decision,
+	// computed fresh per execution. The worker just passes it through to the
+	// CLI via --skip-initial-turn.
+	SkipInitialTurn bool `json:"skip_initial_turn"`
 }
 
 // TaskClaimedMessage is sent from worker to server after successfully claiming a task

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -42,10 +42,11 @@ type TaskAssignmentMessage struct {
 	// AdditionalSidecars is a list of extra sidecar images to mount into the task container.
 	AdditionalSidecars []SidecarMount `json:"additional_sidecars,omitempty"`
 	// SkipInitialTurn mirrors the warp-server-4 wire shape: the server's
-	// shouldSkipInitialTurn helper is the single authority for the decision,
+	// ShouldSkipInitialTurn helper is the single authority for the decision,
 	// computed fresh per execution. The worker just passes it through to the
-	// CLI via --skip-initial-turn.
-	SkipInitialTurn bool `json:"skip_initial_turn"`
+	// CLI via --skip-initial-turn. The omitempty tag matches the server's
+	// emission so a false value never appears on the wire.
+	SkipInitialTurn bool `json:"skip_initial_turn,omitempty"`
 }
 
 // TaskClaimedMessage is sent from worker to server after successfully claiming a task

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -41,12 +41,9 @@ type TaskAssignmentMessage struct {
 	EnvVars map[string]string `json:"env_vars,omitempty"`
 	// AdditionalSidecars is a list of extra sidecar images to mount into the task container.
 	AdditionalSidecars []SidecarMount `json:"additional_sidecars,omitempty"`
-	// SkipInitialTurn mirrors the warp-server-4 wire shape: the server's
-	// ShouldSkipInitialTurn helper is the single authority for the decision,
-	// computed fresh per execution. The worker just passes it through to the
-	// CLI via --skip-initial-turn. The omitempty tag matches the server's
-	// emission so a false value never appears on the wire.
-	SkipInitialTurn bool `json:"skip_initial_turn,omitempty"`
+	// AdditionalOzArgs are server-resolved supplemental arguments for the oz
+	// CLI. The worker forwards these tokens without deriving task semantics.
+	AdditionalOzArgs []string `json:"additional_oz_args,omitempty"`
 }
 
 // TaskClaimedMessage is sent from worker to server after successfully claiming a task

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -427,8 +427,8 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		w.config.ServerRootURL,
 	)
 	baseArgs = common.AugmentArgsForTask(task, baseArgs, common.TaskAugmentOptions{
-		IdleOnComplete:  w.config.IdleOnComplete,
-		SkipInitialTurn: assignment.SkipInitialTurn,
+		IdleOnComplete:   w.config.IdleOnComplete,
+		AdditionalOzArgs: assignment.AdditionalOzArgs,
 	})
 	if w.config.SessionSharingServerURL != "" {
 		baseArgs = append(baseArgs, "--session-sharing-server-url", w.config.SessionSharingServerURL)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -426,8 +426,9 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		"--server-root-url",
 		w.config.ServerRootURL,
 	)
-	baseArgs = common.AugmentArgsForTask(task, assignment.SkipInitialTurn, baseArgs, common.TaskAugmentOptions{
-		IdleOnComplete: w.config.IdleOnComplete,
+	baseArgs = common.AugmentArgsForTask(task, baseArgs, common.TaskAugmentOptions{
+		IdleOnComplete:  w.config.IdleOnComplete,
+		SkipInitialTurn: assignment.SkipInitialTurn,
 	})
 	if w.config.SessionSharingServerURL != "" {
 		baseArgs = append(baseArgs, "--session-sharing-server-url", w.config.SessionSharingServerURL)

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -426,7 +426,7 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		"--server-root-url",
 		w.config.ServerRootURL,
 	)
-	baseArgs = common.AugmentArgsForTask(task, assignment.ExecutionInput, baseArgs, common.TaskAugmentOptions{
+	baseArgs = common.AugmentArgsForTask(task, assignment.SkipInitialTurn, baseArgs, common.TaskAugmentOptions{
 		IdleOnComplete: w.config.IdleOnComplete,
 	})
 	if w.config.SessionSharingServerURL != "" {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -426,7 +426,7 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		"--server-root-url",
 		w.config.ServerRootURL,
 	)
-	baseArgs = common.AugmentArgsForTask(task, baseArgs, common.TaskAugmentOptions{
+	baseArgs = common.AugmentArgsForTask(task, assignment.ExecutionInput, baseArgs, common.TaskAugmentOptions{
 		IdleOnComplete: w.config.IdleOnComplete,
 	})
 	if w.config.SessionSharingServerURL != "" {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -488,6 +488,57 @@ func TestPrepareTaskParamsIncludesServerRootURLForHarnessSupport(t *testing.T) {
 	}
 	t.Fatalf("expected %s in env vars, got %v", want, params.EnvVars)
 }
+
+// TestPrepareTaskParamsSkipInitialTurn locks in the passthrough wiring from
+// TaskAssignmentMessage.SkipInitialTurn through prepareTaskParams into the
+// CLI args. The bare unit test on AugmentArgsForTask is necessary but not
+// sufficient: this test guards against worker.go regressing the field-to-opts
+// mapping at the call site.
+func TestPrepareTaskParamsSkipInitialTurn(t *testing.T) {
+	newWorker := func() *Worker {
+		return &Worker{
+			ctx: context.Background(),
+			config: Config{
+				ServerRootURL: "https://app.warp.dev",
+				Kubernetes:    &KubernetesBackendConfig{},
+			},
+		}
+	}
+
+	containsSkipInitialTurn := func(args []string) bool {
+		for _, arg := range args {
+			if arg == "--skip-initial-turn" {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("forwards --skip-initial-turn when assignment.SkipInitialTurn is true", func(t *testing.T) {
+		w := newWorker()
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID:          "task-skip",
+			Task:            &types.Task{ID: "task-skip"},
+			SkipInitialTurn: true,
+		})
+		if !containsSkipInitialTurn(params.BaseArgs) {
+			t.Fatalf("expected --skip-initial-turn in args, got %v", params.BaseArgs)
+		}
+	})
+
+	t.Run("omits --skip-initial-turn when assignment.SkipInitialTurn is false", func(t *testing.T) {
+		w := newWorker()
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID:          "task-no-skip",
+			Task:            &types.Task{ID: "task-no-skip"},
+			SkipInitialTurn: false,
+		})
+		if containsSkipInitialTurn(params.BaseArgs) {
+			t.Fatalf("did not expect --skip-initial-turn in args, got %v", params.BaseArgs)
+		}
+	})
+}
+
 func TestWorkerShutdownUsesFreshContextForBackendCleanup(t *testing.T) {
 	workerCtx, cancel := context.WithCancel(context.Background())
 	backend := &shutdownRecordingBackend{}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -489,12 +489,7 @@ func TestPrepareTaskParamsIncludesServerRootURLForHarnessSupport(t *testing.T) {
 	t.Fatalf("expected %s in env vars, got %v", want, params.EnvVars)
 }
 
-// TestPrepareTaskParamsSkipInitialTurn locks in the passthrough wiring from
-// TaskAssignmentMessage.SkipInitialTurn through prepareTaskParams into the
-// CLI args. The bare unit test on AugmentArgsForTask is necessary but not
-// sufficient: this test guards against worker.go regressing the field-to-opts
-// mapping at the call site.
-func TestPrepareTaskParamsSkipInitialTurn(t *testing.T) {
+func TestPrepareTaskParamsAdditionalOzArgs(t *testing.T) {
 	newWorker := func() *Worker {
 		return &Worker{
 			ctx: context.Background(),
@@ -514,24 +509,22 @@ func TestPrepareTaskParamsSkipInitialTurn(t *testing.T) {
 		return false
 	}
 
-	t.Run("forwards --skip-initial-turn when assignment.SkipInitialTurn is true", func(t *testing.T) {
+	t.Run("forwards server supplemental oz args", func(t *testing.T) {
 		w := newWorker()
 		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
-			TaskID:          "task-skip",
-			Task:            &types.Task{ID: "task-skip"},
-			SkipInitialTurn: true,
+			TaskID:           "task-skip",
+			Task:             &types.Task{ID: "task-skip"},
+			AdditionalOzArgs: []string{"--skip-initial-turn"},
 		})
 		if !containsSkipInitialTurn(params.BaseArgs) {
 			t.Fatalf("expected --skip-initial-turn in args, got %v", params.BaseArgs)
 		}
 	})
-
-	t.Run("omits --skip-initial-turn when assignment.SkipInitialTurn is false", func(t *testing.T) {
+	t.Run("does not add omitted supplemental oz args", func(t *testing.T) {
 		w := newWorker()
 		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
-			TaskID:          "task-no-skip",
-			Task:            &types.Task{ID: "task-no-skip"},
-			SkipInitialTurn: false,
+			TaskID: "task-no-skip",
+			Task:   &types.Task{ID: "task-no-skip"},
 		})
 		if containsSkipInitialTurn(params.BaseArgs) {
 			t.Fatalf("did not expect --skip-initial-turn in args, got %v", params.BaseArgs)


### PR DESCRIPTION
In [this server PR](https://github.com/warpdotdev/warp-server/pull/11432), we pass in a skip initial turn field to the worker when we're doing handoff w/ no prompt (otherwise, the agent tries to kick off a turn with no prompt, the server resolves the prompt to empty, and we just stream a response for an empty input). We need to correctly handle this field in the worker