### PR TITLE
Explicitly set exporter to none

### DIFF
--- a/charts/oz-agent-worker/templates/deployment.yaml
+++ b/charts/oz-agent-worker/templates/deployment.yaml
@@ -81,6 +81,11 @@ spec:
             {{- with .Values.metrics.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+            {{- else }}
+            # The worker defaults an unset exporter to OTLP, so disabling
+            # chart-managed metrics must explicitly disable metric export.
+            - name: OTEL_METRICS_EXPORTER
+              value: "none"
             {{- end }}
           {{- if and .Values.metrics.enabled (eq .Values.metrics.exporter "prometheus") }}
           ports:


### PR DESCRIPTION
Before this change, `metrics.enabled=false` did not set OTEL_METRICS_EXPORTER in the worker pod. An unset exporter causes the OpenTelemetry package default to OTLP, so workers with metrics disabled still attempted to send metrics to the default local collector endpoint. Because no collector is running in the pod, customers saw repeated errors in their work pods such as:

`failed to upload metrics: Post "https://localhost:4318/v1/metrics": dial tcp [::1]:4318: connect: connection refused`

This change makes the disabled Helm default explicit by setting `OTEL_METRICS_EXPORTER=none`, preventing unintended metric export attempts and eliminating the misleading log noise.

Verified before and after in a kind cluster.