### PR TITLE
Preserve failed Kubernetes task jobs for debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ backend:
     kubeconfig: "/path/to/kubeconfig"
     namespace: "agents"
     default_image: "my-registry.io/dev-image:latest"
+    preserve_failed_jobs: true
     unschedulable_timeout: "2m"
     pod_template:
       nodeSelector:
@@ -98,6 +99,7 @@ Notes:
 - `default_image` sets the Docker image for task Jobs when no Warp environment is configured on the run; this lets you skip creating a Warp environment entirely if all your tasks use the same base image (precedence: Warp environment image > `default_image` > `ubuntu:22.04`)
 - `namespace` selects the namespace inside the chosen cluster; it does not choose the cluster itself, and defaults to `default` when omitted
 - `unschedulable_timeout` controls how long a Pod may remain unschedulable before the task is failed early; it defaults to `30s`, and `0s` disables that fail-fast behavior
+- `preserve_failed_jobs` controls whether failed task Jobs and Pods are left in place for debugging; it defaults to true. When cleanup is enabled, `ttl_seconds_after_finished` still bounds how long failed Jobs remain after they reach a terminal state
 - `image_pull_policy` defaults to `IfNotPresent`
 - `sidecar_image` overrides the warp-agent sidecar image reference sent by the server (e.g. `docker.io/warpdotdev/warp-agent:latest`); set this when cluster nodes cannot pull directly from Docker Hub and must use an internal registry mirror or pull-through cache instead. This only affects the warp-agent sidecar (mounted at `/agent`), not any additional sidecars. When using this override, you are responsible for keeping your mirror in sync with `docker.io/warpdotdev/warp-agent` — the server normally sends the correct version-matched image per task, so a stale mirror may cause version incompatibility
 - by default, the Kubernetes backend materializes sidecars with root init containers into `emptyDir` volumes, matching the existing behavior
@@ -121,6 +123,11 @@ pod_template:
               key: secret-key
 ```
 
+To support different Kubernetes pod sizes without making every run expensive,
+deploy multiple Helm releases with distinct `worker.workerId` values and
+different `kubernetesBackend.podTemplate` resource settings. Select the
+corresponding self-hosted worker/host for runs that need the larger profile,
+while keeping the default worker on smaller requests and limits.
 
 ### Helm Chart
 
@@ -174,7 +181,10 @@ tolerations, or disruption budgets) so worker rotation does not imply task pod
 eviction.
 
 When cleanup is enabled, completed task Jobs are still cleaned up by normal
-worker cleanup when observed, with Kubernetes Job TTL as a fallback.
+worker cleanup when observed, with Kubernetes Job TTL as a fallback. Failed task
+Jobs are preserved by default so operators can inspect the Pod, Events, and
+container logs after startup or runtime failures; disable this with
+`kubernetesBackend.preserveFailedJobs=false` if immediate cleanup is preferred.
 
 Recommended namespace-scoped permissions for the worker are:
 

--- a/charts/oz-agent-worker/templates/configmap.yaml
+++ b/charts/oz-agent-worker/templates/configmap.yaml
@@ -49,6 +49,7 @@ data:
         {{- if and .Values.worker.cleanup .Values.kubernetesBackend.ttlSecondsAfterFinished }}
         ttl_seconds_after_finished: {{ .Values.kubernetesBackend.ttlSecondsAfterFinished }}
         {{- end }}
+        preserve_failed_jobs: {{ .Values.kubernetesBackend.preserveFailedJobs }}
         {{- if .Values.kubernetesBackend.workspaceSizeLimit }}
         workspace_size_limit: {{ .Values.kubernetesBackend.workspaceSizeLimit | quote }}
         {{- end }}

--- a/charts/oz-agent-worker/values.yaml
+++ b/charts/oz-agent-worker/values.yaml
@@ -87,6 +87,10 @@ kubernetesBackend:
   # them has been disrupted. When worker.cleanup=false, the worker does not set
   # a TTL so Jobs remain available for debugging.
   ttlSecondsAfterFinished: 86400
+  # Keep failed task Jobs and Pods around for debugging startup and runtime
+  # failures. With cleanup enabled, ttlSecondsAfterFinished still bounds how
+  # long failed Jobs remain after they reach a terminal state.
+  preserveFailedJobs: true
   workspaceSizeLimit: ""
   unschedulableTimeout: "30s"
   # Optional: raw Kubernetes PodSpec YAML for task Jobs. Configure task-pod

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -67,6 +67,7 @@ type KubernetesConfig struct {
 	ExtraAnnotations      map[string]string `yaml:"extra_annotations"`
 	ActiveDeadlineSeconds *int64            `yaml:"active_deadline_seconds"`
 	TTLSecondsAfterFinish *int32            `yaml:"ttl_seconds_after_finished"`
+	PreserveFailedJobs    *bool             `yaml:"preserve_failed_jobs"`
 	WorkspaceSizeLimit    string            `yaml:"workspace_size_limit"`
 	UnschedulableTimeout  *string           `yaml:"unschedulable_timeout"`
 	// PodTemplate holds a raw Kubernetes PodSpec that is merged with the worker's

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -280,6 +280,7 @@ backend:
     extra_annotations:
       owner: "oz"
     active_deadline_seconds: 1800
+    preserve_failed_jobs: false
     workspace_size_limit: "10Gi"
     unschedulable_timeout: "2m"
     pod_template:
@@ -324,6 +325,9 @@ backend:
 	}
 	if cfg.Backend.Kubernetes.WorkspaceSizeLimit != "10Gi" {
 		t.Fatalf("workspace_size_limit = %v, want 10Gi", cfg.Backend.Kubernetes.WorkspaceSizeLimit)
+	}
+	if cfg.Backend.Kubernetes.PreserveFailedJobs == nil || *cfg.Backend.Kubernetes.PreserveFailedJobs {
+		t.Fatalf("preserve_failed_jobs = %v, want false", cfg.Backend.Kubernetes.PreserveFailedJobs)
 	}
 	if cfg.Backend.Kubernetes.UnschedulableTimeout == nil || *cfg.Backend.Kubernetes.UnschedulableTimeout != "2m" {
 		t.Fatalf("unschedulable_timeout = %v, want 2m", cfg.Backend.Kubernetes.UnschedulableTimeout)

--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -67,6 +67,7 @@ type KubernetesBackendConfig struct {
 	ExtraAnnotations      map[string]string
 	ActiveDeadlineSeconds *int64
 	TTLSecondsAfterFinish *int32
+	PreserveFailedJobs    *bool
 	WorkspaceSizeLimit    *resource.Quantity
 	UnschedulableTimeout  *time.Duration
 	// TaskEnv contains runtime-only env overrides from CLI -e/--env. Declarative
@@ -128,7 +129,7 @@ func NewKubernetesBackend(ctx context.Context, config KubernetesBackendConfig) (
 }
 
 // ExecuteTask runs the agent in a Kubernetes Job.
-func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams) error {
+func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams) (retErr error) {
 	if err := validateTaskSidecars(params.Sidecars, b.config.UseImageVolumes); err != nil {
 		return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonSidecarPrep, err)
 	}
@@ -295,6 +296,10 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 			log.Infof(ctx, "Leaving Kubernetes Job %s in place after task context cancellation", jobName)
 			return
 		}
+		if b.shouldPreserveFailedJob(retErr) {
+			log.Infof(ctx, "Leaving failed Kubernetes Job %s in place for debugging", jobName)
+			return
+		}
 		if !b.config.NoCleanup {
 			if err := b.deleteJob(context.Background(), jobName); err != nil {
 				log.Warnf(ctx, "Failed to delete Job %s: %v", jobName, err)
@@ -403,6 +408,16 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 			}
 		}
 	}
+}
+
+func (b *KubernetesBackend) shouldPreserveFailedJob(err error) bool {
+	if err == nil || b.config.NoCleanup {
+		return false
+	}
+	if b.config.PreserveFailedJobs != nil {
+		return *b.config.PreserveFailedJobs
+	}
+	return true
 }
 
 // Shutdown intentionally does not delete task Jobs.

--- a/internal/worker/kubernetes_test.go
+++ b/internal/worker/kubernetes_test.go
@@ -20,6 +20,9 @@ import (
 func durationPtr(value time.Duration) *time.Duration {
 	return &value
 }
+func boolPtr(value bool) *bool {
+	return &value
+}
 
 func TestSanitizeKubernetesJobNameUsesHashSuffix(t *testing.T) {
 	first := sanitizeKubernetesJobName("Task A")
@@ -956,6 +959,143 @@ func TestExecuteTaskPreservesJobOnContextCancellation(t *testing.T) {
 
 	if _, err := fakeClient.BatchV1().Jobs("agents").Get(context.Background(), jobName, metav1.GetOptions{}); err != nil {
 		t.Fatalf("expected Job %s to be preserved after context cancellation, got %v", jobName, err)
+	}
+}
+func TestExecuteTaskPreservesFailedJobByDefault(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	jobWatch := watch.NewFake()
+	podWatch := watch.NewFake()
+	defer jobWatch.Stop()
+	defer podWatch.Stop()
+
+	var createdJob *batchv1.Job
+	fakeClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateActionImpl)
+		if !ok {
+			t.Fatalf("expected create action, got %T", action)
+		}
+		job, ok := createAction.GetObject().(*batchv1.Job)
+		if !ok {
+			t.Fatalf("expected Job object, got %T", createAction.GetObject())
+		}
+		createdJob = job.DeepCopy()
+		return false, nil, nil
+	})
+	fakeClient.PrependWatchReactor("jobs", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			if createdJob == nil {
+				return
+			}
+			failedJob := createdJob.DeepCopy()
+			failedJob.Status.Conditions = []batchv1.JobCondition{
+				{
+					Type:   batchv1.JobFailed,
+					Status: corev1.ConditionTrue,
+					Reason: "BackoffLimitExceeded",
+				},
+			}
+			jobWatch.Modify(failedJob)
+		}()
+		return true, jobWatch, nil
+	})
+	fakeClient.PrependWatchReactor("pods", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		return true, podWatch, nil
+	})
+
+	backend := &KubernetesBackend{
+		config: KubernetesBackendConfig{
+			WorkerID:  "worker-123",
+			Namespace: "agents",
+		},
+		clientset: fakeClient,
+	}
+
+	err := backend.ExecuteTask(context.Background(), &TaskParams{
+		TaskID:      "task-1",
+		DockerImage: "ubuntu:22.04",
+		BaseArgs:    []string{"run"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed") {
+		t.Fatalf("expected failed job error, got %v", err)
+	}
+	if createdJob == nil {
+		t.Fatal("expected task Job to be created")
+	}
+	if _, err := fakeClient.BatchV1().Jobs("agents").Get(context.Background(), createdJob.Name, metav1.GetOptions{}); err != nil {
+		t.Fatalf("expected failed Job %s to be preserved, got %v", createdJob.Name, err)
+	}
+	for _, action := range fakeClient.Actions() {
+		if action.Matches("delete", "jobs") {
+			t.Fatalf("expected no delete action for failed Job, got %v", action)
+		}
+	}
+}
+
+func TestExecuteTaskDeletesFailedJobWhenPreservationDisabled(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	jobWatch := watch.NewFake()
+	podWatch := watch.NewFake()
+	defer jobWatch.Stop()
+	defer podWatch.Stop()
+
+	var createdJob *batchv1.Job
+	fakeClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateActionImpl)
+		if !ok {
+			t.Fatalf("expected create action, got %T", action)
+		}
+		job, ok := createAction.GetObject().(*batchv1.Job)
+		if !ok {
+			t.Fatalf("expected Job object, got %T", createAction.GetObject())
+		}
+		createdJob = job.DeepCopy()
+		return false, nil, nil
+	})
+	fakeClient.PrependWatchReactor("jobs", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			if createdJob == nil {
+				return
+			}
+			failedJob := createdJob.DeepCopy()
+			failedJob.Status.Conditions = []batchv1.JobCondition{
+				{
+					Type:   batchv1.JobFailed,
+					Status: corev1.ConditionTrue,
+					Reason: "BackoffLimitExceeded",
+				},
+			}
+			jobWatch.Modify(failedJob)
+		}()
+		return true, jobWatch, nil
+	})
+	fakeClient.PrependWatchReactor("pods", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		return true, podWatch, nil
+	})
+
+	backend := &KubernetesBackend{
+		config: KubernetesBackendConfig{
+			WorkerID:           "worker-123",
+			Namespace:          "agents",
+			PreserveFailedJobs: boolPtr(false),
+		},
+		clientset: fakeClient,
+	}
+
+	err := backend.ExecuteTask(context.Background(), &TaskParams{
+		TaskID:      "task-1",
+		DockerImage: "ubuntu:22.04",
+		BaseArgs:    []string{"run"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "failed") {
+		t.Fatalf("expected failed job error, got %v", err)
+	}
+	if createdJob == nil {
+		t.Fatal("expected task Job to be created")
+	}
+	if _, err := fakeClient.BatchV1().Jobs("agents").Get(context.Background(), createdJob.Name, metav1.GetOptions{}); err == nil {
+		t.Fatalf("expected failed Job %s to be deleted when preservation is disabled", createdJob.Name)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -197,6 +197,7 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 			extraAnnotations      map[string]string
 			activeDeadlineSeconds *int64
 			ttlSecondsAfterFinish *int32
+			preserveFailedJobs    *bool
 			workspaceSizeLimit    *resource.Quantity
 			unschedulableTimeout  *time.Duration
 			podTemplate           *corev1.PodSpec
@@ -217,6 +218,7 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 			extraAnnotations = copyStringMap(kc.ExtraAnnotations)
 			activeDeadlineSeconds = kc.ActiveDeadlineSeconds
 			ttlSecondsAfterFinish = kc.TTLSecondsAfterFinish
+			preserveFailedJobs = kc.PreserveFailedJobs
 			if kc.WorkspaceSizeLimit != "" {
 				quantity, err := resource.ParseQuantity(kc.WorkspaceSizeLimit)
 				if err != nil {
@@ -260,6 +262,7 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 			ExtraAnnotations:      extraAnnotations,
 			ActiveDeadlineSeconds: activeDeadlineSeconds,
 			TTLSecondsAfterFinish: ttlSecondsAfterFinish,
+			PreserveFailedJobs:    preserveFailedJobs,
 			WorkspaceSizeLimit:    workspaceSizeLimit,
 			UnschedulableTimeout:  unschedulableTimeout,
 			TaskEnv:               copyStringMap(cliEnv),

--- a/main_test.go
+++ b/main_test.go
@@ -74,6 +74,7 @@ func TestMergeConfigKubernetesFromFile(t *testing.T) {
 					"owner": "oz",
 				},
 				ActiveDeadlineSeconds: int64Ptr(900),
+				PreserveFailedJobs:    boolPtr(false),
 				WorkspaceSizeLimit:    "8Gi",
 				UnschedulableTimeout:  stringPtr("2m"),
 				PodTemplate: rawYAMLNodeFromString(t, `
@@ -121,6 +122,9 @@ containers:
 	}
 	if wc.Kubernetes.WorkspaceSizeLimit == nil || wc.Kubernetes.WorkspaceSizeLimit.String() != "8Gi" {
 		t.Fatalf("WorkspaceSizeLimit = %v, want 8Gi", wc.Kubernetes.WorkspaceSizeLimit)
+	}
+	if wc.Kubernetes.PreserveFailedJobs == nil || *wc.Kubernetes.PreserveFailedJobs {
+		t.Fatalf("PreserveFailedJobs = %v, want false", wc.Kubernetes.PreserveFailedJobs)
 	}
 	if wc.Kubernetes.UnschedulableTimeout == nil || *wc.Kubernetes.UnschedulableTimeout != 2*time.Minute {
 		t.Fatalf("UnschedulableTimeout = %v, want 2m", wc.Kubernetes.UnschedulableTimeout)


### PR DESCRIPTION
## Summary

- Preserve failed Kubernetes task Jobs by default so self-hosted operators can inspect Pods, Events, and logs after startup/runtime failures.
- Add `preserve_failed_jobs` / `kubernetesBackend.preserveFailedJobs` config with an opt-out path for immediate cleanup.
- Document resource-profile guidance for deploying multiple worker releases with different task pod resource settings, plus bounded failed-job cleanup behavior.

## Testing

- `go -C /workspace/oz-agent-worker test ./...`
- `git -C /workspace/oz-agent-worker --no-pager diff --check`

Helm validation was not run because `helm` is not installed in this worker environment.

_Conversation: https://staging.warp.dev/conversation/dc8c9fee-bfa7-42cb-bcec-df6074261860_
_Run: https://oz.staging.warp.dev/runs/019e902a-8037-7eab-94a3-d874e057cbda_

Co-Authored-By: Oz <oz-agent@warp.dev>

_This PR was generated with [Oz](https://warp.dev/oz)._
