### PR TITLE
[REMOTE-1820] Handle cancellation requests from dispatch server

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -70,7 +70,6 @@ type instruments struct {
 	connected          metric.Int64Gauge
 	tasksActive        metric.Int64UpDownCounter
 	tasksMaxConcurrent metric.Int64Gauge
-	tasksClaimed       metric.Int64Counter
 	tasksRejected      metric.Int64Counter
 	tasksCompleted     metric.Int64Counter
 	taskDuration       metric.Float64Histogram
@@ -120,6 +119,7 @@ const (
 	TaskFailureReasonInvalidImage    = "invalid_image"
 	TaskFailureReasonActiveDeadline  = "active_deadline"
 	TaskFailureReasonCleanup         = "cleanup"
+
 )
 
 var (
@@ -275,7 +275,6 @@ func shouldInitTraces() bool {
 func primeInstruments(ctx context.Context, set *instruments) {
 	set.connected.Record(ctx, 0)
 	set.tasksActive.Add(ctx, 0)
-	set.tasksClaimed.Add(ctx, 0)
 	set.tasksRejected.Add(ctx, 0,
 		metric.WithAttributes(attribute.String("reason", RejectReasonAtCapacity)),
 	)
@@ -343,13 +342,6 @@ func buildInstruments(m metric.Meter) (*instruments, error) {
 	if err != nil {
 		return nil, err
 	}
-	tasksClaimed, err := m.Int64Counter(
-		"oz_worker_tasks_claimed_total",
-		metric.WithDescription("Total tasks the worker has claimed since process start."),
-	)
-	if err != nil {
-		return nil, err
-	}
 	tasksRejected, err := m.Int64Counter(
 		"oz_worker_tasks_rejected_total",
 		metric.WithDescription("Total tasks the worker has rejected since process start."),
@@ -397,7 +389,6 @@ func buildInstruments(m metric.Meter) (*instruments, error) {
 		connected:          connected,
 		tasksActive:        tasksActive,
 		tasksMaxConcurrent: tasksMaxConcurrent,
-		tasksClaimed:       tasksClaimed,
 		tasksRejected:      tasksRejected,
 		tasksCompleted:     tasksCompleted,
 		taskDuration:       taskDuration,
@@ -435,11 +426,6 @@ func DecTasksActive() {
 // to render saturation.
 func SetMaxConcurrent(n int) {
 	current().tasksMaxConcurrent.Record(context.Background(), int64(n))
-}
-
-// RecordTaskClaim records a successful task claim (the worker has accepted a task).
-func RecordTaskClaim() {
-	current().tasksClaimed.Add(context.Background(), 1)
 }
 
 // RecordTaskRejected records a task that the worker rejected, e.g. because

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -70,6 +70,7 @@ type instruments struct {
 	connected          metric.Int64Gauge
 	tasksActive        metric.Int64UpDownCounter
 	tasksMaxConcurrent metric.Int64Gauge
+	tasksClaimed       metric.Int64Counter
 	tasksRejected      metric.Int64Counter
 	tasksCompleted     metric.Int64Counter
 	taskDuration       metric.Float64Histogram
@@ -119,7 +120,6 @@ const (
 	TaskFailureReasonInvalidImage    = "invalid_image"
 	TaskFailureReasonActiveDeadline  = "active_deadline"
 	TaskFailureReasonCleanup         = "cleanup"
-
 )
 
 var (
@@ -275,6 +275,7 @@ func shouldInitTraces() bool {
 func primeInstruments(ctx context.Context, set *instruments) {
 	set.connected.Record(ctx, 0)
 	set.tasksActive.Add(ctx, 0)
+	set.tasksClaimed.Add(ctx, 0)
 	set.tasksRejected.Add(ctx, 0,
 		metric.WithAttributes(attribute.String("reason", RejectReasonAtCapacity)),
 	)
@@ -342,6 +343,13 @@ func buildInstruments(m metric.Meter) (*instruments, error) {
 	if err != nil {
 		return nil, err
 	}
+	tasksClaimed, err := m.Int64Counter(
+		"oz_worker_tasks_claimed_total",
+		metric.WithDescription("Total tasks the worker has claimed since process start."),
+	)
+	if err != nil {
+		return nil, err
+	}
 	tasksRejected, err := m.Int64Counter(
 		"oz_worker_tasks_rejected_total",
 		metric.WithDescription("Total tasks the worker has rejected since process start."),
@@ -389,6 +397,7 @@ func buildInstruments(m metric.Meter) (*instruments, error) {
 		connected:          connected,
 		tasksActive:        tasksActive,
 		tasksMaxConcurrent: tasksMaxConcurrent,
+		tasksClaimed:       tasksClaimed,
 		tasksRejected:      tasksRejected,
 		tasksCompleted:     tasksCompleted,
 		taskDuration:       taskDuration,
@@ -426,6 +435,11 @@ func DecTasksActive() {
 // to render saturation.
 func SetMaxConcurrent(n int) {
 	current().tasksMaxConcurrent.Record(context.Background(), int64(n))
+}
+
+// RecordTaskClaim records a successful task claim (the worker has accepted a task).
+func RecordTaskClaim() {
+	current().tasksClaimed.Add(context.Background(), 1)
 }
 
 // RecordTaskRejected records a task that the worker rejected, e.g. because

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -9,12 +9,13 @@ import (
 type MessageType string
 
 const (
-	MessageTypeTaskAssignment MessageType = "task_assignment"
-	MessageTypeTaskClaimed    MessageType = "task_claimed"
-	MessageTypeTaskCompleted  MessageType = "task_completed"
-	MessageTypeTaskFailed     MessageType = "task_failed"
-	MessageTypeTaskRejected   MessageType = "task_rejected"
-	MessageTypeHeartbeat      MessageType = "heartbeat"
+	MessageTypeTaskAssignment   MessageType = "task_assignment"
+	MessageTypeTaskClaimed      MessageType = "task_claimed"
+	MessageTypeTaskCompleted    MessageType = "task_completed"
+	MessageTypeTaskFailed       MessageType = "task_failed"
+	MessageTypeTaskRejected     MessageType = "task_rejected"
+	MessageTypeTaskCancellation MessageType = "task_cancellation"
+	MessageTypeHeartbeat        MessageType = "heartbeat"
 )
 
 // WebSocketMessage is the base structure for all WebSocket messages
@@ -58,14 +59,16 @@ type TaskClaimedMessage struct {
 
 // TaskCompletedMessage tells the server to end the active run execution after a successful agent process exit.
 type TaskCompletedMessage struct {
-	TaskID  string `json:"task_id"`
-	Message string `json:"message"`
+	TaskID    string     `json:"task_id"`
+	Message   string     `json:"message"`
+	TaskState *TaskState `json:"task_state,omitempty"`
 }
 
 // TaskFailedMessage is sent from worker to server if task launch fails
 type TaskFailedMessage struct {
-	TaskID  string `json:"task_id"`
-	Message string `json:"message"`
+	TaskID    string     `json:"task_id"`
+	Message   string     `json:"message"`
+	TaskState *TaskState `json:"task_state,omitempty"`
 }
 
 // TaskRejectedMessage is sent from worker to server when the worker cannot accept the task
@@ -74,6 +77,18 @@ type TaskRejectedMessage struct {
 	TaskID string `json:"task_id"`
 	Reason string `json:"reason"`
 }
+
+// TaskCancellationMessage is sent from server to worker to cancel an active task.
+type TaskCancellationMessage struct {
+	TaskID string `json:"task_id"`
+}
+
+// TaskState is the serialized terminal task state accepted by warp-server.
+type TaskState string
+
+const (
+	TaskStateCancelled TaskState = "CANCELLED"
+)
 
 type TaskDefinition struct {
 	Prompt string `json:"prompt"`

--- a/internal/worker/direct.go
+++ b/internal/worker/direct.go
@@ -202,6 +202,9 @@ func (b *DirectBackend) ExecuteTask(ctx context.Context, params *TaskParams) err
 
 		log.Infof(ctx, "Running setup command: %s", b.config.SetupCommand)
 		if err := b.runCommand(ctx, b.config.SetupCommand, workspaceDir, setupEnv); err != nil {
+			if ctx.Err() != nil {
+				return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonTaskCancelled, ctx.Err())
+			}
 			return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonSetupCommand, fmt.Errorf("setup command failed: %w", err))
 		}
 	}
@@ -232,6 +235,9 @@ func (b *DirectBackend) ExecuteTask(ctx context.Context, params *TaskParams) err
 	log.Debugf(ctx, "Command: %s %s", b.ozPath, strings.Join(params.BaseArgs, " "))
 
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonTaskCancelled, ctx.Err())
+		}
 		return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonAgentInvocation, fmt.Errorf("oz agent exited with error: %w", err))
 	}
 

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -153,7 +153,9 @@ func (b *DockerBackend) ExecuteTask(ctx context.Context, params *TaskParams) err
 
 	defer func() {
 		if containerID != "" && !b.config.NoCleanup {
-			if _, removeErr := dockerClient.ContainerRemove(ctx, containerID, client.ContainerRemoveOptions{Force: true}); removeErr != nil {
+			cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), BackendShutdownTimeout)
+			defer cleanupCancel()
+			if _, removeErr := dockerClient.ContainerRemove(cleanupCtx, containerID, client.ContainerRemoveOptions{Force: true}); removeErr != nil {
 				log.Debugf(ctx, "Container %s already removed or removal failed: %v", containerID, removeErr)
 			}
 		}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -359,7 +359,6 @@ func (w *Worker) handleTaskAssignment(assignment *types.TaskAssignmentMessage) {
 	if err := w.sendTaskClaimed(assignment.TaskID); err != nil {
 		log.Errorf(w.ctx, "Failed to send task claimed message: %v", err)
 	}
-	metrics.RecordTaskClaim()
 	metrics.AddTaskEvent(taskCtx, "task.claimed")
 	metrics.IncTasksActive()
 	select {
@@ -412,20 +411,14 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 	baseArgs := []string{
 		"agent",
 		"run",
-	}
-	// Only share with the team when the task is team-owned. User-owned tasks
-	// (created with "Team visible" unchecked) use user-scoped API keys that
-	// cannot set up team-level session sharing.
-	if task.Owner.IsTeamOwned() {
-		baseArgs = append(baseArgs, "--share", "team:edit")
-	}
-	baseArgs = append(baseArgs,
+		"--share",
+		"team:edit",
 		"--task-id",
 		task.ID,
 		"--sandboxed",
 		"--server-root-url",
 		w.config.ServerRootURL,
-	)
+	}
 	baseArgs = common.AugmentArgsForTask(task, baseArgs, common.TaskAugmentOptions{
 		IdleOnComplete:   w.config.IdleOnComplete,
 		AdditionalOzArgs: assignment.AdditionalOzArgs,

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -3,6 +3,7 @@ package worker
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/url"
 	"sync"
@@ -61,10 +62,15 @@ type Worker struct {
 	reconnectDelay time.Duration
 	lastHeartbeat  time.Time
 	sendChan       chan []byte
-	activeTasks    map[string]context.CancelFunc
+	activeTasks    map[string]activeTask
 	tasksMutex     sync.Mutex
 	backend        Backend
 	taskSemaphore  *semaphore.Weighted // nil when unlimited
+}
+
+type activeTask struct {
+	ctx    context.Context
+	cancel context.CancelFunc
 }
 
 func New(ctx context.Context, config Config) (*Worker, error) {
@@ -111,7 +117,7 @@ func New(ctx context.Context, config Config) (*Worker, error) {
 		cancel:         cancel,
 		reconnectDelay: InitialReconnectDelay,
 		sendChan:       make(chan []byte, 256),
-		activeTasks:    make(map[string]context.CancelFunc),
+		activeTasks:    make(map[string]activeTask),
 		backend:        backend,
 		taskSemaphore:  taskSemaphore,
 	}, nil
@@ -324,9 +330,34 @@ func (w *Worker) handleMessage(message []byte) {
 		}
 		w.handleTaskAssignment(&assignment)
 
+	case types.MessageTypeTaskCancellation:
+		var cancellation types.TaskCancellationMessage
+		if err := json.Unmarshal(msg.Data, &cancellation); err != nil {
+			log.Errorf(w.ctx, "Failed to unmarshal task cancellation: %v", err)
+			return
+		}
+		w.handleTaskCancellation(&cancellation)
+
 	default:
 		log.Warnf(w.ctx, "Unknown message type: %s", msg.Type)
 	}
+}
+
+func (w *Worker) handleTaskCancellation(cancellation *types.TaskCancellationMessage) {
+	w.tasksMutex.Lock()
+	task, ok := w.activeTasks[cancellation.TaskID]
+	w.tasksMutex.Unlock()
+	if !ok {
+		log.Warnf(w.ctx, "Received cancellation for inactive task: taskID=%s", cancellation.TaskID)
+		return
+	}
+
+	log.Infof(w.ctx, "Cancelling task from server request: taskID=%s", cancellation.TaskID)
+	metrics.AddTaskEvent(task.ctx, "task.cancellation_requested",
+		attribute.String("source", "server"),
+		attribute.String("task.id", cancellation.TaskID),
+	)
+	task.cancel()
 }
 
 func (w *Worker) handleTaskAssignment(assignment *types.TaskAssignmentMessage) {
@@ -380,7 +411,10 @@ func (w *Worker) handleTaskAssignment(assignment *types.TaskAssignmentMessage) {
 	taskCtx, taskCancel := context.WithCancel(executionCtx)
 
 	w.tasksMutex.Lock()
-	w.activeTasks[assignment.TaskID] = taskCancel
+	w.activeTasks[assignment.TaskID] = activeTask{
+		ctx:    taskCtx,
+		cancel: taskCancel,
+	}
 	w.tasksMutex.Unlock()
 	go w.executeTask(taskCtx, taskCancel, span, assignment, receivedAt)
 }
@@ -411,14 +445,20 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 	baseArgs := []string{
 		"agent",
 		"run",
-		"--share",
-		"team:edit",
+	}
+	// Only share with the team when the task is team-owned. User-owned tasks
+	// (created with "Team visible" unchecked) use user-scoped API keys that
+	// cannot set up team-level session sharing.
+	if task.Owner.IsTeamOwned() {
+		baseArgs = append(baseArgs, "--share", "team:edit")
+	}
+	baseArgs = append(baseArgs,
 		"--task-id",
 		task.ID,
 		"--sandboxed",
 		"--server-root-url",
 		w.config.ServerRootURL,
-	}
+	)
 	baseArgs = common.AugmentArgsForTask(task, baseArgs, common.TaskAugmentOptions{
 		IdleOnComplete:   w.config.IdleOnComplete,
 		AdditionalOzArgs: assignment.AdditionalOzArgs,
@@ -505,6 +545,17 @@ func (w *Worker) executeTask(ctx context.Context, taskCancel context.CancelFunc,
 
 	err := w.backend.ExecuteTask(ctx, params)
 	if err != nil {
+		if errors.Is(err, context.Canceled) {
+			result = metrics.TaskResultCancelled
+			metrics.AddTaskEvent(ctx, "task.cancelled")
+			span.SetStatus(codes.Ok, "task cancelled")
+			log.Infof(ctx, "Task execution cancelled: taskID=%s", taskID)
+			if statusErr := w.sendTaskCancelled(taskID, "Task cancelled."); statusErr != nil {
+				log.Errorf(ctx, "Failed to send task cancelled message: %v", statusErr)
+			}
+			return
+		}
+
 		result = metrics.TaskResultFailed
 		phase, reason := taskFailureLabels(err)
 		metrics.RecordTaskFailure(phase, reason)
@@ -543,6 +594,32 @@ func (w *Worker) sendTaskClaimed(taskID string) error {
 
 	msg := types.WebSocketMessage{
 		Type: types.MessageTypeTaskClaimed,
+		Data: data,
+	}
+
+	msgBytes, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal websocket message: %w", err)
+	}
+
+	return w.sendMessage(msgBytes)
+}
+
+func (w *Worker) sendTaskCancelled(taskID, message string) error {
+	taskState := types.TaskStateCancelled
+	completedMsg := types.TaskCompletedMessage{
+		TaskID:    taskID,
+		Message:   message,
+		TaskState: &taskState,
+	}
+
+	data, err := json.Marshal(completedMsg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal task cancelled message: %w", err)
+	}
+
+	msg := types.WebSocketMessage{
+		Type: types.MessageTypeTaskCompleted,
 		Data: data,
 	}
 
@@ -647,9 +724,13 @@ func (w *Worker) Shutdown() {
 		log.Infof(w.ctx, "Preserving %d active tasks during worker shutdown", activeTaskCount)
 	} else if activeTaskCount > 0 {
 		log.Infof(w.ctx, "Cancelling %d active tasks", activeTaskCount)
-		for taskID, cancel := range w.activeTasks {
+		for taskID, task := range w.activeTasks {
 			log.Debugf(w.ctx, "Cancelling task: %s", taskID)
-			cancel()
+			metrics.AddTaskEvent(task.ctx, "task.cancellation_requested",
+				attribute.String("source", "signal"),
+				attribute.String("task.id", taskID),
+			)
+			task.cancel()
 		}
 	}
 	w.tasksMutex.Unlock()

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -3,7 +3,6 @@ package worker
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"sync"
@@ -67,10 +66,17 @@ type Worker struct {
 	backend        Backend
 	taskSemaphore  *semaphore.Weighted // nil when unlimited
 }
+type taskCancellationSource string
+
+const (
+	taskCancellationSourceUser     taskCancellationSource = "user"
+	taskCancellationSourceShutdown taskCancellationSource = "shutdown"
+)
 
 type activeTask struct {
-	ctx    context.Context
-	cancel context.CancelFunc
+	ctx                context.Context
+	cancel             context.CancelFunc
+	cancellationSource taskCancellationSource
 }
 
 func New(ctx context.Context, config Config) (*Worker, error) {
@@ -346,6 +352,10 @@ func (w *Worker) handleMessage(message []byte) {
 func (w *Worker) handleTaskCancellation(cancellation *types.TaskCancellationMessage) {
 	w.tasksMutex.Lock()
 	task, ok := w.activeTasks[cancellation.TaskID]
+	if ok && task.cancellationSource == "" {
+		task.cancellationSource = taskCancellationSourceUser
+		w.activeTasks[cancellation.TaskID] = task
+	}
 	w.tasksMutex.Unlock()
 	if !ok {
 		log.Warnf(w.ctx, "Received cancellation for inactive task: taskID=%s", cancellation.TaskID)
@@ -546,12 +556,14 @@ func (w *Worker) executeTask(ctx context.Context, taskCancel context.CancelFunc,
 
 	err := w.backend.ExecuteTask(ctx, params)
 	if err != nil {
-		if errors.Is(err, context.Canceled) {
+		if ctx.Err() == context.Canceled && w.cancellationSource(taskID) == taskCancellationSourceUser {
 			result = metrics.TaskResultCancelled
-			metrics.AddTaskEvent(ctx, "task.cancelled")
-			span.SetStatus(codes.Ok, "task cancelled")
-			log.Infof(ctx, "Task execution cancelled: taskID=%s", taskID)
-			if statusErr := w.sendTaskCancelled(taskID, "Task cancelled."); statusErr != nil {
+			metrics.AddTaskEvent(ctx, "task.cancelled",
+				attribute.String("source", string(taskCancellationSourceUser)),
+			)
+			span.SetStatus(codes.Ok, "task cancelled by user request")
+			log.Infof(ctx, "Task execution cancelled by user request: taskID=%s", taskID)
+			if statusErr := w.sendTaskCancelled(taskID, "Task cancelled by user request."); statusErr != nil {
 				log.Errorf(ctx, "Failed to send task cancelled message: %v", statusErr)
 			}
 			return
@@ -582,6 +594,16 @@ func (w *Worker) executeTask(ctx context.Context, taskCancel context.CancelFunc,
 	}
 }
 
+func (w *Worker) cancellationSource(taskID string) taskCancellationSource {
+	w.tasksMutex.Lock()
+	defer w.tasksMutex.Unlock()
+
+	task, ok := w.activeTasks[taskID]
+	if !ok {
+		return ""
+	}
+	return task.cancellationSource
+}
 func (w *Worker) sendTaskClaimed(taskID string) error {
 	claimed := types.TaskClaimedMessage{
 		TaskID:   taskID,
@@ -726,6 +748,10 @@ func (w *Worker) Shutdown() {
 	} else if activeTaskCount > 0 {
 		log.Infof(w.ctx, "Cancelling %d active tasks", activeTaskCount)
 		for taskID, task := range w.activeTasks {
+			if task.cancellationSource == "" {
+				task.cancellationSource = taskCancellationSourceShutdown
+				w.activeTasks[taskID] = task
+			}
 			log.Debugf(w.ctx, "Cancelling task: %s", taskID)
 			metrics.AddTaskEvent(task.ctx, "task.cancellation_requested",
 				attribute.String("source", "signal"),

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -390,6 +390,7 @@ func (w *Worker) handleTaskAssignment(assignment *types.TaskAssignmentMessage) {
 	if err := w.sendTaskClaimed(assignment.TaskID); err != nil {
 		log.Errorf(w.ctx, "Failed to send task claimed message: %v", err)
 	}
+	metrics.RecordTaskClaim()
 	metrics.AddTaskEvent(taskCtx, "task.claimed")
 	metrics.IncTasksActive()
 	select {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -98,16 +98,20 @@ func TestTaskFailureLabels(t *testing.T) {
 	}
 }
 
-func TestExecuteTaskReportsTaskCancelledOnContextCancellation(t *testing.T) {
+func TestExecuteTaskReportsTaskCancelledOnUserCancellation(t *testing.T) {
+	taskCtx, taskCancel := context.WithCancel(context.Background())
+	taskCancel()
 	w := &Worker{
-		ctx:         context.Background(),
-		config:      Config{},
-		sendChan:    make(chan []byte, 1),
-		activeTasks: map[string]activeTask{"task-1": {cancel: func() {}}},
-		backend:     &recordingBackend{err: context.Canceled},
+		ctx:      context.Background(),
+		config:   Config{},
+		sendChan: make(chan []byte, 1),
+		activeTasks: map[string]activeTask{"task-1": {
+			cancel:             func() {},
+			cancellationSource: taskCancellationSourceUser,
+		}},
+		backend: &recordingBackend{err: context.Canceled},
 	}
-
-	w.executeTask(context.Background(), func() {}, trace.SpanFromContext(context.Background()), &types.TaskAssignmentMessage{
+	w.executeTask(taskCtx, func() {}, trace.SpanFromContext(taskCtx), &types.TaskAssignmentMessage{
 		TaskID: "task-1",
 		Task:   &types.Task{ID: "task-1", Title: "test task"},
 	}, time.Now())
@@ -127,8 +131,31 @@ func TestExecuteTaskReportsTaskCancelledOnContextCancellation(t *testing.T) {
 	if completed.TaskState == nil || *completed.TaskState != types.TaskStateCancelled {
 		t.Fatalf("task state = %v, want %q", completed.TaskState, types.TaskStateCancelled)
 	}
+	if completed.Message != "Task cancelled by user request." {
+		t.Errorf("message = %q, want %q", completed.Message, "Task cancelled by user request.")
+	}
 	if _, ok := w.activeTasks["task-1"]; ok {
 		t.Fatal("task should be removed from active tasks")
+	}
+}
+
+func TestExecuteTaskDoesNotReportTaskCancelledOnBackendCancellationError(t *testing.T) {
+	w := &Worker{
+		ctx:         context.Background(),
+		config:      Config{},
+		sendChan:    make(chan []byte, 1),
+		activeTasks: map[string]activeTask{"task-1": {cancel: func() {}}},
+		backend:     &recordingBackend{err: fmt.Errorf("backend request failed: %w", context.Canceled)},
+	}
+
+	w.executeTask(context.Background(), func() {}, trace.SpanFromContext(context.Background()), &types.TaskAssignmentMessage{
+		TaskID: "task-1",
+		Task:   &types.Task{ID: "task-1", Title: "test task"},
+	}, time.Now())
+
+	msg := readWebSocketMessage(t, w.sendChan)
+	if msg.Type != types.MessageTypeTaskFailed {
+		t.Fatalf("message type = %q, want %q", msg.Type, types.MessageTypeTaskFailed)
 	}
 }
 
@@ -163,6 +190,9 @@ func TestHandleMessageCancelsActiveTask(t *testing.T) {
 
 	if taskCtx.Err() != context.Canceled {
 		t.Fatalf("task context error = %v, want %v", taskCtx.Err(), context.Canceled)
+	}
+	if task := w.activeTasks["task-1"]; task.cancellationSource != taskCancellationSourceUser {
+		t.Fatalf("task cancellation source = %q, want %q", task.cancellationSource, taskCancellationSourceUser)
 	}
 }
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -107,7 +107,7 @@ func TestExecuteTaskReportsTaskCancelledOnContextCancellation(t *testing.T) {
 		backend:     &recordingBackend{err: context.Canceled},
 	}
 
-	w.executeTask(context.Background(), trace.SpanFromContext(context.Background()), &types.TaskAssignmentMessage{
+	w.executeTask(context.Background(), func() {}, trace.SpanFromContext(context.Background()), &types.TaskAssignmentMessage{
 		TaskID: "task-1",
 		Task:   &types.Task{ID: "task-1", Title: "test task"},
 	}, time.Now())
@@ -234,41 +234,12 @@ func TestExecuteTaskReportsTaskFailedOnBackendError(t *testing.T) {
 	}
 }
 
-func TestExecuteTaskReportsUserFriendlyMessageOnContextCanceled(t *testing.T) {
-	w := &Worker{
-		ctx:         context.Background(),
-		config:      Config{},
-		sendChan:    make(chan []byte, 1),
-		activeTasks: map[string]context.CancelFunc{"task-1": func() {}},
-		backend:     &recordingBackend{err: context.Canceled},
-	}
-
-	w.executeTask(context.Background(), func() {}, trace.SpanFromContext(context.Background()), &types.TaskAssignmentMessage{
-		TaskID: "task-1",
-		Task:   &types.Task{ID: "task-1", Title: "test task"},
-	}, time.Now())
-
-	msg := readWebSocketMessage(t, w.sendChan)
-	if msg.Type != types.MessageTypeTaskFailed {
-		t.Fatalf("message type = %q, want %q", msg.Type, types.MessageTypeTaskFailed)
-	}
-
-	var failed types.TaskFailedMessage
-	if err := json.Unmarshal(msg.Data, &failed); err != nil {
-		t.Fatalf("failed to unmarshal task failed message: %v", err)
-	}
-	want := "The task was interrupted due to an infrastructure issue (context canceled). This is typically transient — please try again."
-	if failed.Message != want {
-		t.Errorf("message = %q, want %q", failed.Message, want)
-	}
-}
-
 func TestExecuteTaskReportsUserFriendlyMessageOnDeadlineExceeded(t *testing.T) {
 	w := &Worker{
 		ctx:         context.Background(),
 		config:      Config{},
 		sendChan:    make(chan []byte, 1),
-		activeTasks: map[string]context.CancelFunc{"task-1": func() {}},
+		activeTasks: map[string]activeTask{"task-1": {cancel: func() {}}},
 		backend:     &recordingBackend{err: context.DeadlineExceeded},
 	}
 
@@ -627,10 +598,10 @@ func TestWorkerShutdownPreservesActiveTasksForPreservingBackend(t *testing.T) {
 	w := &Worker{
 		ctx:    workerCtx,
 		cancel: cancel,
-		activeTasks: map[string]context.CancelFunc{
-			"task-1": func() {
+		activeTasks: map[string]activeTask{
+			"task-1": {cancel: func() {
 				cancelledTask = true
-			},
+			}},
 		},
 		backend: backend,
 	}
@@ -653,7 +624,7 @@ func TestHandleTaskAssignmentDoesNotStartTaskAfterShutdownDuringClaim(t *testing
 		cancel:      cancel,
 		config:      Config{},
 		sendChan:    make(chan []byte, 1),
-		activeTasks: make(map[string]context.CancelFunc),
+		activeTasks: make(map[string]activeTask),
 		backend:     &preservingShutdownRecordingBackend{},
 	}
 

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -98,12 +98,80 @@ func TestTaskFailureLabels(t *testing.T) {
 	}
 }
 
+func TestExecuteTaskReportsTaskCancelledOnContextCancellation(t *testing.T) {
+	w := &Worker{
+		ctx:         context.Background(),
+		config:      Config{},
+		sendChan:    make(chan []byte, 1),
+		activeTasks: map[string]activeTask{"task-1": {cancel: func() {}}},
+		backend:     &recordingBackend{err: context.Canceled},
+	}
+
+	w.executeTask(context.Background(), trace.SpanFromContext(context.Background()), &types.TaskAssignmentMessage{
+		TaskID: "task-1",
+		Task:   &types.Task{ID: "task-1", Title: "test task"},
+	}, time.Now())
+
+	msg := readWebSocketMessage(t, w.sendChan)
+	if msg.Type != types.MessageTypeTaskCompleted {
+		t.Fatalf("message type = %q, want %q", msg.Type, types.MessageTypeTaskCompleted)
+	}
+
+	var completed types.TaskCompletedMessage
+	if err := json.Unmarshal(msg.Data, &completed); err != nil {
+		t.Fatalf("failed to unmarshal task completed message: %v", err)
+	}
+	if completed.TaskID != "task-1" {
+		t.Errorf("task ID = %q, want %q", completed.TaskID, "task-1")
+	}
+	if completed.TaskState == nil || *completed.TaskState != types.TaskStateCancelled {
+		t.Fatalf("task state = %v, want %q", completed.TaskState, types.TaskStateCancelled)
+	}
+	if _, ok := w.activeTasks["task-1"]; ok {
+		t.Fatal("task should be removed from active tasks")
+	}
+}
+
+func TestHandleMessageCancelsActiveTask(t *testing.T) {
+	taskCtx, taskCancel := context.WithCancel(context.Background())
+	defer taskCancel()
+
+	w := &Worker{
+		ctx:      context.Background(),
+		sendChan: make(chan []byte, 1),
+		activeTasks: map[string]activeTask{
+			"task-1": {
+				ctx:    taskCtx,
+				cancel: taskCancel,
+			},
+		},
+	}
+
+	data, err := json.Marshal(types.TaskCancellationMessage{TaskID: "task-1"})
+	if err != nil {
+		t.Fatalf("failed to marshal cancellation message: %v", err)
+	}
+	message, err := json.Marshal(types.WebSocketMessage{
+		Type: types.MessageTypeTaskCancellation,
+		Data: data,
+	})
+	if err != nil {
+		t.Fatalf("failed to marshal websocket message: %v", err)
+	}
+
+	w.handleMessage(message)
+
+	if taskCtx.Err() != context.Canceled {
+		t.Fatalf("task context error = %v, want %v", taskCtx.Err(), context.Canceled)
+	}
+}
+
 func TestExecuteTaskReportsTaskCompletedOnSuccess(t *testing.T) {
 	w := &Worker{
 		ctx:         context.Background(),
 		config:      Config{},
 		sendChan:    make(chan []byte, 1),
-		activeTasks: map[string]context.CancelFunc{"task-1": func() {}},
+		activeTasks: map[string]activeTask{"task-1": {cancel: func() {}}},
 		backend:     &recordingBackend{},
 	}
 
@@ -137,7 +205,7 @@ func TestExecuteTaskReportsTaskFailedOnBackendError(t *testing.T) {
 		ctx:         context.Background(),
 		config:      Config{},
 		sendChan:    make(chan []byte, 1),
-		activeTasks: map[string]context.CancelFunc{"task-1": func() {}},
+		activeTasks: map[string]activeTask{"task-1": {cancel: func() {}}},
 		backend:     &recordingBackend{err: errors.New("boom")},
 	}
 
@@ -538,7 +606,7 @@ func TestWorkerShutdownUsesFreshContextForBackendCleanup(t *testing.T) {
 	w := &Worker{
 		ctx:         workerCtx,
 		cancel:      cancel,
-		activeTasks: make(map[string]context.CancelFunc),
+		activeTasks: make(map[string]activeTask),
 		backend:     backend,
 	}
 


### PR DESCRIPTION
## Summary

This is the worker-side half of REMOTE-1820: self-hosted worker cancellation support.

The companion `warp-server` change now forwards `task_cancellation` control messages to the worker. This PR makes `oz-agent-worker` consume those messages, cancel the matching active task context, and report the task back as terminal `CANCELLED` rather than as a normal failure.

End to end:
- Adds the `task_cancellation` WebSocket message and a shared `TaskStateCancelled` wire value.
- Tracks each active task's context and cancel function so the worker can cancel only the requested task.
- Cancels matching active tasks when a `task_cancellation` control message arrives; cancellations for inactive tasks are logged and ignored.
- Reports cancelled tasks through the existing `task_completed` message shape with `task_state=CANCELLED`, so server-side lifecycle reconciliation can distinguish cancellation from failure.
- Preserves the normal success/failure paths for non-cancelled tasks.
- Records cancellation lifecycle events and marks cancelled executions separately from failed executions.
- Handles context cancellation cleanly in the direct backend and uses bounded Docker cleanup so worker shutdown does not block indefinitely.

## Code overview
- `internal/types/messages.go` — adds `task_cancellation`, `TaskState`, and optional `task_state` fields on terminal worker messages.
- `internal/worker/worker.go` — handles cancellation messages, tracks active task contexts, emits terminal `CANCELLED`, and keeps shutdown cancellation on the same lifecycle path.
- `internal/worker/direct.go` — classifies context cancellation as task cancellation instead of a generic backend failure.
- `internal/worker/docker.go` — bounds container cleanup during cancellation/shutdown.
- `internal/worker/worker_test.go` — covers cancellation message handling, terminal `CANCELLED` reporting, and shutdown behavior.

## Validation
- `go test ./internal/metrics ./internal/worker`
- `go test ./...`
- `helm template oz-agent-worker charts/oz-agent-worker --set image.tag=test --set worker.workerId=test-worker --set warp.apiKeySecret.create=true --set warp.apiKeySecret.value=dummy --set metrics.enabled=true`
- `git diff --check`

Co-Authored-By: Oz <oz-agent@warp.dev>
