### PR TITLE
[REMOTE-1903] Reattach and finalize preserved k8s task Jobs on worker restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,11 +159,21 @@ The chart defaults the long-lived worker `Deployment` to a non-root security con
 The Deployment includes a default `exec` liveness probe that checks the worker process is still running (`kill -0 1`). If the worker becomes unresponsive, Kubernetes will restart the pod after three consecutive failures. Override `worker.livenessProbe` in your values to use a custom probe (e.g. `httpGet` if you add a health endpoint), or set it to `null` to disable.
 
 When the long-lived worker pod is terminated by normal Kubernetes disruption
-(for example Karpenter node consolidation), the Kubernetes backend preserves
-active task Jobs instead of deleting them during worker shutdown. This protects
-running Oz sessions from worker pod rotation as long as the task Job and task Pod
-remain healthy. The default `worker.terminationGracePeriodSeconds` only needs to
-cover WebSocket close and metrics flush.
+(for example Karpenter node consolidation or a spot-instance reclaim of the
+worker node), the Kubernetes backend preserves active task Jobs instead of
+deleting them during worker shutdown. This protects running Oz sessions from
+worker pod rotation as long as the task Job and task Pod remain healthy. The
+default `worker.terminationGracePeriodSeconds` only needs to cover WebSocket
+close and metrics flush.
+
+When the replacement worker pod starts (it keeps the same `worker.workerId`), it
+reattaches to any of its still-running task Jobs, resumes watching them, and
+reports `task_completed` / `task_failed` to Warp when they finish. This means a
+worker pod that is evicted and rescheduled — for example on a spot node pool —
+resumes preserved runs to completion instead of leaving them open until
+server-side stale-task cleanup. Reattachment relies on Job labels/annotations,
+so keep `worker.workerId` stable across restarts. Terminal Jobs are not
+re-reported on restart; they are handled by normal cleanup and Job TTL.
 
 This does not make task Pods disruption-proof. If Karpenter or another cluster
 operation evicts the node that is actually running the task Pod, the live Oz

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -45,3 +45,34 @@ type Backend interface {
 	// Shutdown cleans up backend resources.
 	Shutdown(ctx context.Context)
 }
+
+// ReattachableTask identifies an in-flight task execution unit that a
+// replacement worker can resume monitoring after a restart or relocation.
+type ReattachableTask struct {
+	// TaskID is the logical run ID, used to report terminal task state back to
+	// the control plane.
+	TaskID string
+	// ExecutionID identifies the concrete run execution. It falls back to
+	// TaskID when the execution unit predates execution-scoped identity.
+	ExecutionID string
+	// BackendRef is an opaque backend-specific handle (e.g. a Kubernetes Job
+	// name) used to re-establish monitoring for the existing execution unit.
+	BackendRef string
+}
+
+// ReattachingBackend is an optional capability implemented by backends whose
+// task execution units (for example Kubernetes Jobs) outlive the worker
+// process. It lets a freshly started worker re-adopt and finalize executions
+// that a previous worker pod left running when it was disrupted (for example by
+// Karpenter consolidation or spot-instance reclamation of the worker node).
+type ReattachingBackend interface {
+	Backend
+	// ListReattachableTasks returns the in-flight, non-terminal task execution
+	// units this worker created in a previous lifetime that still need a worker
+	// to monitor them to completion.
+	ListReattachableTasks(ctx context.Context) ([]ReattachableTask, error)
+	// MonitorTask re-establishes monitoring for an already-created execution
+	// unit and blocks until it reaches a terminal state, returning the terminal
+	// outcome the same way ExecuteTask does.
+	MonitorTask(ctx context.Context, task ReattachableTask) error
+}

--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -45,6 +45,12 @@ const (
 	kubernetesExecutionIDLabel       = "oz-execution-id"
 	kubernetesExecutionHashLabel     = "oz-execution-hash"
 
+	// Annotations carry the un-sanitized task and execution identity so a
+	// replacement worker can reconstruct the logical IDs needed to report
+	// terminal task state. Labels are DNS-sanitized and therefore lossy.
+	kubernetesTaskIDAnnotation      = "oz.warp.dev/task-id"
+	kubernetesExecutionIDAnnotation = "oz.warp.dev/execution-id"
+
 	// maxLogBytes caps the amount of container log data read into memory per
 	// container to avoid OOM when a task produces excessive output.
 	maxLogBytes = 1 << 20 // 1 MiB
@@ -136,7 +142,7 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 	executionID := taskExecutionID(params)
 	jobName := sanitizeKubernetesJobName(executionID)
 	jobLabels := b.baseLabels(params.TaskID, executionID)
-	jobAnnotations := copyStringMap(b.config.ExtraAnnotations)
+	jobAnnotations := b.baseAnnotations(params.TaskID, executionID)
 	pullPolicy := normalizePullPolicy(b.config.ImagePullPolicy)
 
 	log.Debugf(ctx, "Using Kubernetes task image: %s", params.DockerImage)
@@ -286,6 +292,15 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 		return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonJobCreate, fmt.Errorf("failed to create Kubernetes Job: %w", err))
 	}
 
+	return b.monitorJob(ctx, jobName, params.TaskID, executionID)
+}
+
+// monitorJob watches an existing task Job until it reaches a terminal state,
+// applying the configured cleanup policy. It is shared by ExecuteTask (after
+// creating the Job) and MonitorTask (reattaching to a Job created by a previous
+// worker lifetime). The Job is left in place when the context is cancelled so
+// worker disruption does not destroy a still-running session.
+func (b *KubernetesBackend) monitorJob(ctx context.Context, jobName, taskID, executionID string) error {
 	deleted := false
 	defer func() {
 		if deleted {
@@ -346,7 +361,7 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 			if !ok {
 				continue
 			}
-			if result := b.handleJobState(ctx, jobState, params.TaskID, executionID); result != nil {
+			if result := b.handleJobState(ctx, jobState, taskID, executionID); result != nil {
 				return result.err
 			}
 
@@ -390,7 +405,7 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 				}
 				return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonJobWatch, fmt.Errorf("failed to get Job %s: %w", jobName, err))
 			}
-			if result := b.handleJobState(ctx, jobState, params.TaskID, executionID); result != nil {
+			if result := b.handleJobState(ctx, jobState, taskID, executionID); result != nil {
 				return result.err
 			}
 
@@ -403,6 +418,60 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 			}
 		}
 	}
+}
+
+// ListReattachableTasks lists this worker's still-running task Jobs so a freshly
+// started worker can resume monitoring them after a restart or relocation. Only
+// non-terminal Jobs are returned: terminal Jobs are handled by the existing
+// cleanup path and Job TTL, and re-reporting their terminal state on every
+// restart would be redundant.
+func (b *KubernetesBackend) ListReattachableTasks(ctx context.Context) ([]ReattachableTask, error) {
+	jobs, err := b.clientset.BatchV1().Jobs(b.config.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: fmt.Sprintf("%s=%s", kubernetesWorkerHashLabel, kubernetesLabelHash(b.config.WorkerID)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list reattachable Jobs for worker %s: %w", b.config.WorkerID, err)
+	}
+
+	var tasks []ReattachableTask
+	for i := range jobs.Items {
+		job := &jobs.Items[i]
+		if jobComplete(job) || jobFailed(job) {
+			continue
+		}
+		taskID := job.Annotations[kubernetesTaskIDAnnotation]
+		if taskID == "" {
+			// Without the un-sanitized task ID we cannot report terminal state
+			// to the control plane, so skip rather than guess from labels.
+			log.Warnf(ctx, "Skipping reattach for Job %s: missing %s annotation", job.Name, kubernetesTaskIDAnnotation)
+			continue
+		}
+		executionID := job.Annotations[kubernetesExecutionIDAnnotation]
+		if executionID == "" {
+			executionID = taskID
+		}
+		tasks = append(tasks, ReattachableTask{
+			TaskID:      taskID,
+			ExecutionID: executionID,
+			BackendRef:  job.Name,
+		})
+	}
+	return tasks, nil
+}
+
+// MonitorTask reattaches to an already-created task Job and blocks until it
+// reaches a terminal state.
+func (b *KubernetesBackend) MonitorTask(ctx context.Context, task ReattachableTask) error {
+	executionID := strings.TrimSpace(task.ExecutionID)
+	if executionID == "" {
+		executionID = task.TaskID
+	}
+	jobName := task.BackendRef
+	if jobName == "" {
+		jobName = sanitizeKubernetesJobName(executionID)
+	}
+	log.Infof(ctx, "Reattaching to Kubernetes Job %s for task %s in namespace %s", jobName, task.TaskID, b.config.Namespace)
+	return b.monitorJob(ctx, jobName, task.TaskID, executionID)
 }
 
 // Shutdown intentionally does not delete task Jobs.
@@ -813,6 +882,22 @@ func (b *KubernetesBackend) baseLabels(taskID, executionID string) map[string]st
 	labels[kubernetesExecutionIDLabel] = sanitizeKubernetesLabelValue(executionID)
 	labels[kubernetesExecutionHashLabel] = kubernetesLabelHash(executionID)
 	return labels
+}
+
+// baseAnnotations returns the Job annotations, including the un-sanitized task
+// and execution identity that lets a replacement worker reconstruct the logical
+// IDs needed to report terminal task state when reattaching.
+func (b *KubernetesBackend) baseAnnotations(taskID, executionID string) map[string]string {
+	if strings.TrimSpace(executionID) == "" {
+		executionID = taskID
+	}
+	annotations := copyStringMap(b.config.ExtraAnnotations)
+	if annotations == nil {
+		annotations = make(map[string]string, 2)
+	}
+	annotations[kubernetesTaskIDAnnotation] = taskID
+	annotations[kubernetesExecutionIDAnnotation] = executionID
+	return annotations
 }
 
 func (b *KubernetesBackend) listTaskPods(ctx context.Context, executionID string) ([]corev1.Pod, error) {

--- a/internal/worker/kubernetes_test.go
+++ b/internal/worker/kubernetes_test.go
@@ -21,6 +21,141 @@ func durationPtr(value time.Duration) *time.Duration {
 	return &value
 }
 
+func workerLabeledJob(name, workerID, taskID, executionID string) *batchv1.Job {
+	return &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "agents",
+			Labels: map[string]string{
+				kubernetesWorkerHashLabel: kubernetesLabelHash(workerID),
+			},
+			Annotations: map[string]string{
+				kubernetesTaskIDAnnotation:      taskID,
+				kubernetesExecutionIDAnnotation: executionID,
+			},
+		},
+	}
+}
+
+func TestBaseAnnotationsIncludeTaskIdentity(t *testing.T) {
+	backend := &KubernetesBackend{
+		config: KubernetesBackendConfig{
+			ExtraAnnotations: map[string]string{"team": "platform"},
+		},
+	}
+
+	annotations := backend.baseAnnotations("task-1", "execution-1")
+	if annotations[kubernetesTaskIDAnnotation] != "task-1" {
+		t.Fatalf("task annotation = %q, want %q", annotations[kubernetesTaskIDAnnotation], "task-1")
+	}
+	if annotations[kubernetesExecutionIDAnnotation] != "execution-1" {
+		t.Fatalf("execution annotation = %q, want %q", annotations[kubernetesExecutionIDAnnotation], "execution-1")
+	}
+	if annotations["team"] != "platform" {
+		t.Fatalf("extra annotation = %q, want %q", annotations["team"], "platform")
+	}
+
+	// Execution ID falls back to task ID when empty.
+	fallback := backend.baseAnnotations("task-2", "")
+	if fallback[kubernetesExecutionIDAnnotation] != "task-2" {
+		t.Fatalf("execution annotation fallback = %q, want %q", fallback[kubernetesExecutionIDAnnotation], "task-2")
+	}
+}
+
+func TestListReattachableTasksReturnsNonTerminalAnnotatedJobs(t *testing.T) {
+	const workerID = "worker-123"
+
+	running := workerLabeledJob("oz-task-running", workerID, "task-running", "exec-running")
+
+	completed := workerLabeledJob("oz-task-completed", workerID, "task-completed", "exec-completed")
+	completed.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+
+	failed := workerLabeledJob("oz-task-failed", workerID, "task-failed", "exec-failed")
+	failed.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobFailed, Status: corev1.ConditionTrue}}
+
+	otherWorker := workerLabeledJob("oz-task-other", "worker-999", "task-other", "exec-other")
+
+	noAnnotation := workerLabeledJob("oz-task-noannotation", workerID, "", "")
+	delete(noAnnotation.Annotations, kubernetesTaskIDAnnotation)
+
+	fakeClient := fake.NewSimpleClientset(running, completed, failed, otherWorker, noAnnotation)
+	backend := &KubernetesBackend{
+		config: KubernetesBackendConfig{
+			Namespace: "agents",
+			WorkerID:  workerID,
+		},
+		clientset: fakeClient,
+	}
+
+	tasks, err := backend.ListReattachableTasks(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(tasks) != 1 {
+		t.Fatalf("expected exactly one reattachable task, got %d: %+v", len(tasks), tasks)
+	}
+	got := tasks[0]
+	if got.TaskID != "task-running" {
+		t.Fatalf("task ID = %q, want %q", got.TaskID, "task-running")
+	}
+	if got.ExecutionID != "exec-running" {
+		t.Fatalf("execution ID = %q, want %q", got.ExecutionID, "exec-running")
+	}
+	if got.BackendRef != "oz-task-running" {
+		t.Fatalf("backend ref = %q, want %q", got.BackendRef, "oz-task-running")
+	}
+}
+
+func TestMonitorTaskWatchesExistingJobToCompletion(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	jobWatch := watch.NewFake()
+	podWatch := watch.NewFake()
+	defer jobWatch.Stop()
+	defer podWatch.Stop()
+
+	existingJob := workerLabeledJob("oz-task-existing", "worker-123", "task-1", "execution-1")
+	if _, err := fakeClient.BatchV1().Jobs("agents").Create(context.Background(), existingJob, metav1.CreateOptions{}); err != nil {
+		t.Fatalf("failed to seed existing job: %v", err)
+	}
+
+	fakeClient.PrependWatchReactor("jobs", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			completed := existingJob.DeepCopy()
+			completed.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+			}
+			jobWatch.Modify(completed)
+		}()
+		return true, jobWatch, nil
+	})
+	fakeClient.PrependWatchReactor("pods", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		return true, podWatch, nil
+	})
+
+	backend := &KubernetesBackend{
+		config: KubernetesBackendConfig{
+			Namespace: "agents",
+			WorkerID:  "worker-123",
+		},
+		clientset: fakeClient,
+	}
+
+	err := backend.MonitorTask(context.Background(), ReattachableTask{
+		TaskID:      "task-1",
+		ExecutionID: "execution-1",
+		BackendRef:  "oz-task-existing",
+	})
+	if err != nil {
+		t.Fatalf("unexpected MonitorTask error: %v", err)
+	}
+
+	// With cleanup enabled (NoCleanup=false), the observed terminal Job is deleted.
+	if _, getErr := fakeClient.BatchV1().Jobs("agents").Get(context.Background(), "oz-task-existing", metav1.GetOptions{}); getErr == nil {
+		t.Fatal("expected reattached Job to be deleted after completion")
+	}
+}
+
 func TestSanitizeKubernetesJobNameUsesHashSuffix(t *testing.T) {
 	first := sanitizeKubernetesJobName("Task A")
 	second := sanitizeKubernetesJobName("Task-A")

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -65,6 +65,9 @@ type Worker struct {
 	tasksMutex     sync.Mutex
 	backend        Backend
 	taskSemaphore  *semaphore.Weighted // nil when unlimited
+	// reattachOnce guards the one-time reattach pass that re-adopts task
+	// execution units a previous worker lifetime left running.
+	reattachOnce sync.Once
 }
 type taskCancellationSource string
 
@@ -205,6 +208,15 @@ func (w *Worker) run() {
 	go w.readLoop(done)
 	go w.writeLoop(done)
 	go w.heartbeatLoop(done)
+
+	// After the first successful connection, re-adopt any task execution units
+	// a previous worker lifetime left running (e.g. after the worker pod was
+	// relocated by Karpenter or a spot-instance reclaim). This runs once for the
+	// life of the process; the writeLoop above drains the resulting status
+	// messages over the now-established connection.
+	w.reattachOnce.Do(func() {
+		go w.reattachPreservedTasks()
+	})
 
 	<-done
 
@@ -428,6 +440,102 @@ func (w *Worker) handleTaskAssignment(assignment *types.TaskAssignmentMessage) {
 	}
 	w.tasksMutex.Unlock()
 	go w.executeTask(taskCtx, taskCancel, span, assignment, receivedAt)
+}
+
+// reattachPreservedTasks re-adopts task execution units that a previous worker
+// lifetime left running, so a replacement worker pod finalizes them instead of
+// leaving the run open until server-side stale-task cleanup fires. It is a no-op
+// for backends that do not preserve tasks across worker restarts.
+func (w *Worker) reattachPreservedTasks() {
+	rb, ok := w.backend.(ReattachingBackend)
+	if !ok {
+		return
+	}
+
+	tasks, err := rb.ListReattachableTasks(w.ctx)
+	if err != nil {
+		log.Errorf(w.ctx, "Failed to list reattachable tasks: %v", err)
+		return
+	}
+	if len(tasks) == 0 {
+		return
+	}
+
+	log.Infof(w.ctx, "Reattaching to %d preserved task(s) from a previous worker lifetime", len(tasks))
+	for _, task := range tasks {
+		w.reattachTask(rb, task)
+	}
+}
+
+// reattachTask registers a preserved task as active and starts monitoring it to
+// completion. Tasks already tracked by this worker (for example because a fresh
+// assignment arrived first) are skipped.
+func (w *Worker) reattachTask(rb ReattachingBackend, task ReattachableTask) {
+	w.tasksMutex.Lock()
+	if _, exists := w.activeTasks[task.TaskID]; exists {
+		w.tasksMutex.Unlock()
+		log.Debugf(w.ctx, "Skipping reattach for already-active task %s", task.TaskID)
+		return
+	}
+	// Reattach only applies to preserving backends, so detach the task context
+	// from the worker context the same way fresh assignments do: a subsequent
+	// worker shutdown must not cancel monitoring of a still-running execution.
+	executionCtx := context.WithoutCancel(w.ctx)
+	taskCtx, taskCancel := context.WithCancel(executionCtx)
+	w.activeTasks[task.TaskID] = activeTask{
+		ctx:    taskCtx,
+		cancel: taskCancel,
+	}
+	w.tasksMutex.Unlock()
+
+	// Reattached tasks represent pre-existing work rather than a fresh claim, so
+	// they are not counted against the configured concurrency semaphore.
+	metrics.IncTasksActive()
+	go w.monitorReattachedTask(taskCtx, taskCancel, rb, task)
+}
+
+// monitorReattachedTask blocks until a reattached task execution reaches a
+// terminal state and reports the outcome to the control plane, mirroring the
+// finalization logic in executeTask.
+func (w *Worker) monitorReattachedTask(ctx context.Context, taskCancel context.CancelFunc, rb ReattachingBackend, task ReattachableTask) {
+	start := time.Now()
+	result := metrics.TaskResultSucceeded
+
+	defer func() {
+		taskCancel()
+		w.tasksMutex.Lock()
+		delete(w.activeTasks, task.TaskID)
+		w.tasksMutex.Unlock()
+		metrics.DecTasksActive()
+		metrics.RecordTaskCompleted(result, time.Since(start))
+	}()
+
+	log.Infof(w.ctx, "Monitoring reattached task to completion: taskID=%s", task.TaskID)
+	err := rb.MonitorTask(ctx, task)
+	if err != nil {
+		if ctx.Err() == context.Canceled && w.cancellationSource(task.TaskID) == taskCancellationSourceUser {
+			result = metrics.TaskResultCancelled
+			log.Infof(w.ctx, "Reattached task cancelled by user request: taskID=%s", task.TaskID)
+			if statusErr := w.sendTaskCancelled(task.TaskID, "Task cancelled by user request."); statusErr != nil {
+				log.Errorf(w.ctx, "Failed to send task cancelled message: %v", statusErr)
+			}
+			return
+		}
+
+		result = metrics.TaskResultFailed
+		phase, reason := taskFailureLabels(err)
+		metrics.RecordTaskFailure(phase, reason)
+		log.Errorf(w.ctx, "Reattached task execution failed: taskID=%s, error=%v", task.TaskID, err)
+		if statusErr := w.sendTaskFailed(task.TaskID, userFacingTaskError(err)); statusErr != nil {
+			log.Errorf(w.ctx, "Failed to send task failed message: %v", statusErr)
+		}
+		return
+	}
+
+	log.Infof(w.ctx, "Reattached task execution completed successfully: taskID=%s", task.TaskID)
+	if statusErr := w.sendTaskCompleted(task.TaskID, "Task completed successfully"); statusErr != nil {
+		log.Errorf(w.ctx, "Failed to send task completed message: %v", statusErr)
+	}
 }
 
 // prepareTaskParams converts a TaskAssignmentMessage into backend-agnostic TaskParams,

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -5,10 +5,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/warpdotdev/oz-agent-worker/internal/metrics"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/warpdotdev/oz-agent-worker/internal/metrics"
 	"github.com/warpdotdev/oz-agent-worker/internal/types"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -49,6 +50,167 @@ func (b *recordingBackend) ExecuteTask(context.Context, *TaskParams) error {
 func (b *recordingBackend) Shutdown(context.Context) {}
 func (b *recordingBackend) PreservesTasksOnShutdown() bool {
 	return false
+}
+
+// reattachingRecordingBackend is a Backend that also implements
+// ReattachingBackend, recording which tasks it was asked to monitor.
+type reattachingRecordingBackend struct {
+	recordingBackend
+	tasks      []ReattachableTask
+	monitorErr error
+
+	mu        sync.Mutex
+	monitored []ReattachableTask
+}
+
+func (b *reattachingRecordingBackend) PreservesTasksOnShutdown() bool {
+	return true
+}
+
+func (b *reattachingRecordingBackend) ListReattachableTasks(context.Context) ([]ReattachableTask, error) {
+	return b.tasks, nil
+}
+
+func (b *reattachingRecordingBackend) MonitorTask(_ context.Context, task ReattachableTask) error {
+	b.mu.Lock()
+	b.monitored = append(b.monitored, task)
+	b.mu.Unlock()
+	return b.monitorErr
+}
+
+func (b *reattachingRecordingBackend) monitoredTasks() []ReattachableTask {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return append([]ReattachableTask(nil), b.monitored...)
+}
+
+func waitForWebSocketMessage(t *testing.T, messages <-chan []byte) types.WebSocketMessage {
+	t.Helper()
+	select {
+	case msgBytes := <-messages:
+		var msg types.WebSocketMessage
+		if err := json.Unmarshal(msgBytes, &msg); err != nil {
+			t.Fatalf("failed to unmarshal websocket message: %v", err)
+		}
+		return msg
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for websocket message")
+	}
+	return types.WebSocketMessage{}
+}
+
+func waitForActiveTasksEmpty(t *testing.T, w *Worker) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		w.tasksMutex.Lock()
+		n := len(w.activeTasks)
+		w.tasksMutex.Unlock()
+		if n == 0 {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatal("timed out waiting for active tasks to drain")
+}
+
+func TestReattachPreservedTasksReportsCompletion(t *testing.T) {
+	backend := &reattachingRecordingBackend{
+		tasks: []ReattachableTask{{TaskID: "task-1", ExecutionID: "exec-1", BackendRef: "job-1"}},
+	}
+	w := &Worker{
+		ctx:         context.Background(),
+		config:      Config{},
+		sendChan:    make(chan []byte, 4),
+		activeTasks: make(map[string]activeTask),
+		backend:     backend,
+	}
+
+	w.reattachPreservedTasks()
+
+	msg := waitForWebSocketMessage(t, w.sendChan)
+	if msg.Type != types.MessageTypeTaskCompleted {
+		t.Fatalf("message type = %q, want %q", msg.Type, types.MessageTypeTaskCompleted)
+	}
+	var completed types.TaskCompletedMessage
+	if err := json.Unmarshal(msg.Data, &completed); err != nil {
+		t.Fatalf("failed to unmarshal task completed message: %v", err)
+	}
+	if completed.TaskID != "task-1" {
+		t.Fatalf("task ID = %q, want %q", completed.TaskID, "task-1")
+	}
+	if monitored := backend.monitoredTasks(); len(monitored) != 1 || monitored[0].BackendRef != "job-1" {
+		t.Fatalf("expected backend to monitor job-1, got %+v", monitored)
+	}
+	waitForActiveTasksEmpty(t, w)
+}
+
+func TestReattachPreservedTasksReportsFailure(t *testing.T) {
+	backend := &reattachingRecordingBackend{
+		tasks:      []ReattachableTask{{TaskID: "task-1", ExecutionID: "exec-1", BackendRef: "job-1"}},
+		monitorErr: errors.New("boom"),
+	}
+	w := &Worker{
+		ctx:         context.Background(),
+		config:      Config{},
+		sendChan:    make(chan []byte, 4),
+		activeTasks: make(map[string]activeTask),
+		backend:     backend,
+	}
+
+	w.reattachPreservedTasks()
+
+	msg := waitForWebSocketMessage(t, w.sendChan)
+	if msg.Type != types.MessageTypeTaskFailed {
+		t.Fatalf("message type = %q, want %q", msg.Type, types.MessageTypeTaskFailed)
+	}
+	waitForActiveTasksEmpty(t, w)
+}
+
+func TestReattachPreservedTasksSkipsAlreadyActiveTask(t *testing.T) {
+	backend := &reattachingRecordingBackend{
+		tasks: []ReattachableTask{{TaskID: "task-1", ExecutionID: "exec-1", BackendRef: "job-1"}},
+	}
+	w := &Worker{
+		ctx:      context.Background(),
+		config:   Config{},
+		sendChan: make(chan []byte, 4),
+		activeTasks: map[string]activeTask{
+			"task-1": {cancel: func() {}},
+		},
+		backend: backend,
+	}
+
+	w.reattachPreservedTasks()
+
+	// Give any erroneously spawned monitor goroutine a chance to run.
+	time.Sleep(50 * time.Millisecond)
+	if monitored := backend.monitoredTasks(); len(monitored) != 0 {
+		t.Fatalf("expected no monitoring for already-active task, got %+v", monitored)
+	}
+	select {
+	case <-w.sendChan:
+		t.Fatal("did not expect a status message for an already-active task")
+	default:
+	}
+}
+
+func TestReattachPreservedTasksNoOpForNonReattachingBackend(t *testing.T) {
+	w := &Worker{
+		ctx:         context.Background(),
+		config:      Config{},
+		sendChan:    make(chan []byte, 1),
+		activeTasks: make(map[string]activeTask),
+		backend:     &recordingBackend{},
+	}
+
+	// Should simply return without panicking or sending messages.
+	w.reattachPreservedTasks()
+	select {
+	case <-w.sendChan:
+		t.Fatal("did not expect a status message for a non-reattaching backend")
+	default:
+	}
 }
 
 func TestTaskFailureLabels(t *testing.T) {

--- a/specs/k8s-worker-drain-and-reattach/TECH.md
+++ b/specs/k8s-worker-drain-and-reattach/TECH.md
@@ -40,13 +40,14 @@ The remaining caveat is Jobs that never reach a terminal state. `ttlSecondsAfter
 There are two different disruption cases behind “zero loss,” and they have different implementation costs.
 ## Worker pod relocated, task pod remains running
 This is the customer’s immediate scenario when Karpenter moves the long-lived worker pod but leaves the task Job/Pod alone. The MVP in this PR is the destructive-behavior fix: worker termination no longer cancels the active task context or deletes the task Job.
-To make this fully zero-loss instead of “do not kill the Job,” the next increment is reattach/reconcile:
-- Persist the Kubernetes Job name, namespace, worker ID, task ID, and current backend state in worker/task execution data when creating a Job.
-- On worker startup, list Jobs labeled with the worker ID/task hash labels and match them to open tasks in the control plane.
-- Recreate local watches for matched Jobs and Pods, then send `task_completed` or `task_failed` when a preserved Job reaches a terminal state.
-- Make finalization idempotent so both the old worker (if it exits slowly) and the replacement worker can safely race to report the same terminal outcome.
-- Add cleanup for orphaned terminal Jobs after successful reconciliation.
-Estimated effort: roughly 2-4 engineering days if the control-plane APIs already expose the needed open-task lookup/update hooks; closer to 1 week if we need to add worker-data persistence or a new reattach handshake.
+To make this fully zero-loss instead of “do not kill the Job,” the next increment is reattach/reconcile. This increment is now implemented for still-running Jobs:
+- Task Jobs are annotated with the un-sanitized task ID (`oz.warp.dev/task-id`) and execution ID (`oz.warp.dev/execution-id`) so a replacement worker can reconstruct the logical identity needed to report terminal state (labels are DNS-sanitized and lossy).
+- On the first successful WebSocket connection after startup, the worker runs a one-time reattach pass (`Worker.reattachPreservedTasks`). The Kubernetes backend exposes `ListReattachableTasks` (lists non-terminal Jobs carrying this worker's `oz-worker-hash` label) and `MonitorTask` (re-establishes Job/Pod watches for an existing Job) via an optional `ReattachingBackend` interface.
+- Reattached tasks are registered in `activeTasks` (deduped against fresh assignments), monitored to completion through the shared `monitorJob` watch loop, and finalized with `task_completed` / `task_failed` / `task_cancelled` exactly like fresh executions. Terminal Jobs are deliberately excluded from reattach to avoid re-reporting; they are handled by the existing cleanup path and `ttlSecondsAfterFinished`.
+Finalization is intended to be idempotent so the old worker (if it exits slowly) and the replacement worker can both report the same terminal outcome; `deleteJob` already tolerates `NotFound`. Server-side idempotency for duplicate terminal reports is assumed.
+Remaining work for this increment:
+- Make the duplicate-terminal-report race explicitly idempotent end-to-end (server-side dedupe contract).
+- Add an explicit reconcile/cleanup sweep for orphaned terminal Jobs that no worker observed (beyond TTL).
 This PR includes a fallback `ttlSecondsAfterFinished` so completed Jobs do not accumulate indefinitely before reattach/reconcile exists. That TTL only applies after the Job reaches a terminal state; it does not replace reattach/finalization and does not stop truly stuck running Jobs without `activeDeadlineSeconds`.
 ## Task pod or task node evicted
 This is a larger project. If Karpenter evicts the actual task pod, the live process, PTY/session stream, and ephemeral workspace state are gone unless we make the agent runtime resumable.
@@ -74,8 +75,9 @@ Parallel sub-agents are not proposed. The change is tightly scoped to one repo a
 - Risk: shutdown-triggered context cancellation is indistinguishable from explicit task cancellation inside `KubernetesBackend.ExecuteTask`. Mitigation: preserve Jobs only for worker-level shutdown, while explicit task cancellation should remain destructive in a follow-up by threading cancellation reason through the backend.
 - Risk: completed Jobs may accumulate if the worker is repeatedly disrupted. Mitigation: keep terminal cleanup when a worker observes completion and add reattach/reconcile cleanup in the follow-up.
 # Follow-ups
-- Persist Kubernetes Job identity in worker data / execution data.
-- On worker startup, list open Jobs for the worker ID and reattach watches for tasks still open in the control plane.
+- [done] Persist Kubernetes Job identity (task/execution ID) in Job annotations.
+- [done] On worker startup, list this worker's still-running Jobs and reattach watches to finalize them when they reach a terminal state.
+- [done] Add customer-facing Karpenter/spot guidance for worker Deployment disruption vs task pod disruption (README).
 - Add an explicit draining state/message in the worker WebSocket protocol so the control plane can distinguish a healthy idle worker from one that is terminating.
-- Add customer-facing Karpenter guidance for worker Deployment disruption vs task pod disruption.
+- Reconcile/clean up orphaned terminal Jobs that finished while no worker was watching, beyond the `ttlSecondsAfterFinished` fallback.
 - Design durable task-pod resume semantics before promising zero loss when Karpenter evicts the task pod itself.


### PR DESCRIPTION
## Summary
Implements graceful **pod-resume** for self-hosted Oz Kubernetes workers so a restarted/relocated worker re-adopts and finalizes the task Jobs it left running — the key building block for running workers on **spot instances** (REMOTE-1903).

The Kubernetes backend already preserves running task Jobs across worker-pod disruption (Karpenter consolidation, spot reclaim of the worker node) instead of deleting them on shutdown. Previously, however, a replacement worker pod did not re-adopt those Jobs, so the run stayed open until server-side stale-task cleanup fired. This PR implements the spec's deferred **reattach/reconcile** increment.

## What changed
- **`ReattachingBackend` interface** (optional capability) with `ListReattachableTasks` and `MonitorTask`, plus a `ReattachableTask` type. Docker/Direct backends do not implement it (their child processes/containers die with the worker host).
- **Durable Job identity**: task Jobs are now annotated with the un-sanitized task ID (`oz.warp.dev/task-id`) and execution ID (`oz.warp.dev/execution-id`), since labels are DNS-sanitized and lossy.
- **Shared `monitorJob`**: the Job/Pod watch loop is extracted from `ExecuteTask` so both fresh execution and reattach reuse the same finalization + cleanup path.
- **Kubernetes reattach**: `ListReattachableTasks` lists this worker's **non-terminal** Jobs (by `oz-worker-hash` label); `MonitorTask` re-establishes watches on an existing Job and blocks until it reaches a terminal state. Terminal Jobs are intentionally excluded (handled by existing cleanup + `ttlSecondsAfterFinished`) to avoid duplicate reporting.
- **Worker wiring**: after the first successful WebSocket connection, the worker runs a one-time reattach pass, registers reattached tasks in `activeTasks` (deduped against fresh assignments, detached from the worker context so a later shutdown preserves them), and reports `task_completed` / `task_failed` / `task_cancelled` exactly like fresh runs.
- **Docs/spec**: README documents the spot/Karpenter reattach behavior and the requirement to keep `worker.workerId` stable; the TECH spec marks the reattach increment as implemented.

## Scope / non-goals
This makes the **worker-pod relocated, task-pod still running** case (the customer's immediate scenario) resume to completion. It does **not** make the **task pod itself** disruption-proof — surviving task-pod eviction requires durable workspace storage and agent/session checkpointing, which remain follow-ups. Reattachment requires `list jobs` permission (already in the chart RBAC).

## Testing
- `go build ./...`, `go vet ./...`, `gofmt -l` clean
- `go test ./...` (new unit tests: reattachable-job listing/filtering, Job identity annotations, `MonitorTask` watch-to-completion + cleanup, and worker-level completion/failure reporting)

_Conversation: https://staging.warp.dev/conversation/88880492-95a9-42d4-aefd-704ed175af70_

_Run: https://oz.staging.warp.dev/runs/019eaf0f-8e78-7adf-8b11-012add2dd41e_

_This PR was generated with [Oz](https://warp.dev/oz)._
