### PR TITLE
Fix concurrent websocket writes crashing the worker (and its metrics exporter)

### DIFF
--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -65,6 +65,9 @@ type Worker struct {
 	tasksMutex     sync.Mutex
 	backend        Backend
 	taskSemaphore  *semaphore.Weighted // nil when unlimited
+	// heartbeatInterval is how often the worker pings the server. It defaults
+	// to HeartbeatInterval and is overridable in tests.
+	heartbeatInterval time.Duration
 }
 type taskCancellationSource string
 
@@ -118,14 +121,15 @@ func New(ctx context.Context, config Config) (*Worker, error) {
 	}
 
 	return &Worker{
-		config:         config,
-		ctx:            workerCtx,
-		cancel:         cancel,
-		reconnectDelay: InitialReconnectDelay,
-		sendChan:       make(chan []byte, 256),
-		activeTasks:    make(map[string]activeTask),
-		backend:        backend,
-		taskSemaphore:  taskSemaphore,
+		config:            config,
+		ctx:               workerCtx,
+		cancel:            cancel,
+		reconnectDelay:    InitialReconnectDelay,
+		sendChan:          make(chan []byte, 256),
+		activeTasks:       make(map[string]activeTask),
+		backend:           backend,
+		taskSemaphore:     taskSemaphore,
+		heartbeatInterval: HeartbeatInterval,
 	}, nil
 }
 
@@ -200,11 +204,23 @@ func (w *Worker) connect() error {
 }
 
 func (w *Worker) run() {
+	w.connMutex.Lock()
+	conn := w.conn
+	w.connMutex.Unlock()
+	if conn == nil {
+		return
+	}
+
 	done := make(chan struct{})
 
-	go w.readLoop(done)
-	go w.writeLoop(done)
-	go w.heartbeatLoop(done)
+	// Each loop is bound to this connection. A loop from a previous
+	// connection must never write to a newer connection: gorilla/websocket
+	// supports at most one concurrent writer per connection, and a stale
+	// writer racing the current one panics the whole process with
+	// "concurrent write to websocket connection".
+	go w.readLoop(conn, done)
+	go w.writeLoop(conn, done)
+	go w.heartbeatLoop(conn, done)
 
 	<-done
 
@@ -220,7 +236,7 @@ func (w *Worker) run() {
 	log.Warnf(w.ctx, "Connection closed, will attempt to reconnect")
 }
 
-func (w *Worker) readLoop(done chan struct{}) {
+func (w *Worker) readLoop(conn *websocket.Conn, done chan struct{}) {
 	defer close(done)
 
 	for {
@@ -228,14 +244,6 @@ func (w *Worker) readLoop(done chan struct{}) {
 		case <-w.ctx.Done():
 			return
 		default:
-		}
-
-		w.connMutex.Lock()
-		conn := w.conn
-		w.connMutex.Unlock()
-
-		if conn == nil {
-			return
 		}
 
 		if err := conn.SetReadDeadline(time.Now().Add(PongWait)); err != nil {
@@ -256,7 +264,10 @@ func (w *Worker) readLoop(done chan struct{}) {
 	}
 }
 
-func (w *Worker) writeLoop(done chan struct{}) {
+// writeLoop is the single writer of data frames on conn. All data messages
+// must go through sendChan; nothing else may call WriteMessage on conn while
+// this loop is running.
+func (w *Worker) writeLoop(conn *websocket.Conn, done chan struct{}) {
 	for {
 		select {
 		case <-w.ctx.Done():
@@ -264,14 +275,6 @@ func (w *Worker) writeLoop(done chan struct{}) {
 		case <-done:
 			return
 		case message := <-w.sendChan:
-			w.connMutex.Lock()
-			conn := w.conn
-			w.connMutex.Unlock()
-
-			if conn == nil {
-				return
-			}
-
 			log.Debugf(w.ctx, "WebSocket sending: %s", string(message))
 
 			if err := conn.SetWriteDeadline(time.Now().Add(WriteWait)); err != nil {
@@ -286,8 +289,12 @@ func (w *Worker) writeLoop(done chan struct{}) {
 	}
 }
 
-func (w *Worker) heartbeatLoop(done chan struct{}) {
-	ticker := time.NewTicker(HeartbeatInterval)
+func (w *Worker) heartbeatLoop(conn *websocket.Conn, done chan struct{}) {
+	interval := w.heartbeatInterval
+	if interval <= 0 {
+		interval = HeartbeatInterval
+	}
+	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
@@ -297,19 +304,12 @@ func (w *Worker) heartbeatLoop(done chan struct{}) {
 		case <-done:
 			return
 		case <-ticker.C:
-			w.connMutex.Lock()
-			conn := w.conn
-			w.connMutex.Unlock()
-
-			if conn == nil {
-				return
-			}
-
-			if err := conn.SetWriteDeadline(time.Now().Add(WriteWait)); err != nil {
-				log.Errorf(w.ctx, "Failed to set write deadline: %v", err)
-				return
-			}
-			if err := conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+			// Pings must use WriteControl: it is the only write method that
+			// gorilla/websocket documents as safe to call concurrently with
+			// the data writes performed by writeLoop. Using WriteMessage here
+			// races writeLoop and panics the process with "concurrent write
+			// to websocket connection".
+			if err := conn.WriteControl(websocket.PingMessage, nil, time.Now().Add(WriteWait)); err != nil {
 				log.Errorf(w.ctx, "Failed to send ping: %v", err)
 				return
 			}
@@ -773,7 +773,11 @@ func (w *Worker) Shutdown() {
 
 	w.connMutex.Lock()
 	if w.conn != nil {
-		if err := w.conn.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")); err != nil {
+		// WriteControl is safe to call concurrently with writeLoop's data
+		// writes and enforces its own deadline, so shutdown can neither panic
+		// the process nor block indefinitely on a wedged connection.
+		closeMessage := websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")
+		if err := w.conn.WriteControl(websocket.CloseMessage, closeMessage, time.Now().Add(WriteWait)); err != nil {
 			log.Warnf(w.ctx, "Failed to send close message: %v", err)
 		}
 		if err := w.conn.Close(); err != nil {

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -5,10 +5,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/warpdotdev/oz-agent-worker/internal/metrics"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
+	"github.com/warpdotdev/oz-agent-worker/internal/metrics"
 	"github.com/warpdotdev/oz-agent-worker/internal/types"
 	"go.opentelemetry.io/otel/trace"
 )
@@ -345,6 +350,101 @@ func readWebSocketMessage(t *testing.T, messages <-chan []byte) types.WebSocketM
 	}
 
 	return types.WebSocketMessage{}
+}
+
+// TestRunHeartbeatAndWritesAreConcurrencySafe is a regression test for the
+// "concurrent write to websocket connection" panic: the heartbeat loop used
+// to send pings via WriteMessage, racing writeLoop's data writes on the same
+// connection and crashing the whole worker process (taking the metrics
+// exporter down with it). It floods the send channel while heartbeats fire
+// every millisecond; before the fix this panicked within the test window.
+func TestRunHeartbeatAndWritesAreConcurrencySafe(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	var messagesReceived, pingsReceived atomic.Int64
+
+	serverConnClosed := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(rw, r, nil)
+		if err != nil {
+			t.Errorf("failed to upgrade connection: %v", err)
+			return
+		}
+		defer close(serverConnClosed)
+		defer conn.Close()
+		conn.SetPingHandler(func(string) error {
+			pingsReceived.Add(1)
+			return nil
+		})
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+			messagesReceived.Add(1)
+		}
+	}))
+	defer srv.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("failed to dial test server: %v", err)
+	}
+	if resp != nil && resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	w := &Worker{
+		config:            Config{},
+		conn:              conn,
+		ctx:               ctx,
+		cancel:            cancel,
+		sendChan:          make(chan []byte, 256),
+		activeTasks:       make(map[string]activeTask),
+		heartbeatInterval: time.Millisecond,
+	}
+
+	runDone := make(chan struct{})
+	go func() {
+		w.run()
+		close(runDone)
+	}()
+
+	// Flood data writes while heartbeats fire so the two write paths overlap
+	// constantly for the duration of the test window.
+	message := []byte(`{"type":"task_claimed","data":{"task_id":"task-1"}}`)
+	deadline := time.After(500 * time.Millisecond)
+flood:
+	for {
+		select {
+		case <-deadline:
+			break flood
+		case w.sendChan <- message:
+		}
+	}
+
+	// Tear down: cancelling the context stops writeLoop/heartbeatLoop, and
+	// closing the connection unblocks readLoop so run() returns.
+	cancel()
+	conn.Close()
+	select {
+	case <-runDone:
+	case <-time.After(5 * time.Second):
+		t.Fatal("run() did not return after context cancellation and connection close")
+	}
+	select {
+	case <-serverConnClosed:
+	case <-time.After(5 * time.Second):
+		t.Fatal("server connection was not closed")
+	}
+
+	if messagesReceived.Load() == 0 {
+		t.Error("expected the server to receive data messages")
+	}
+	if pingsReceived.Load() == 0 {
+		t.Error("expected the server to receive heartbeat pings")
+	}
 }
 
 func TestDefaultImageForTask(t *testing.T) {


### PR DESCRIPTION
## Description

A customer running `warpdotdev/oz-agent-worker:v2026-05-20-16-25-05` reported that `oz_worker_*` Prometheus series go quiet ~20-30 minutes after deploy. The root cause is not in the metrics pipeline: the worker has a websocket write race that eventually kills the whole process (taking the OTEL exporter down with it).

`heartbeatLoop` sent pings with `Conn.WriteMessage`, the data write path, while `writeLoop` concurrently sends task status messages on the same connection. gorilla/websocket supports at most one concurrent writer; when the two writes overlap, gorilla's best-effort detection panics the process with `panic: concurrent write to websocket connection` (and when detection misses, the frame stream is silently corrupted, forcing a reconnect). A second contributing defect: the read/write/heartbeat loops re-read `w.conn` on each iteration, so loops left over from a torn-down connection could write to the newly dialed connection and race its fresh loops.

The fix:
- Send heartbeat pings via `WriteControl`, the only write method gorilla documents as safe to call concurrently with data writes. Same for the shutdown close frame, which also gains a write deadline so shutdown can't hang on a wedged connection.
- Bind each loop to the connection it was spawned for, so stale loops can never touch a newer connection. `writeLoop` is now the single data-frame writer per connection.

> [!NOTE]
> note from dstern: i don't believe that this is the cause of what was reported (see REMOTE-1907), but this does appear to be a real worker stability issue, which we ought to fix anyway.

## Testing

- Reproduced the crash against the unpatched worker: ran it against a stub warp-server websocket endpoint assigning tasks every 15s with `OTEL_METRICS_EXPORTER=prometheus`; it died with `panic: concurrent write to websocket connection` (heartbeat ping racing `writeLoop` in `WriteMessage`) after ~20 tasks, and `/metrics` went down with it.
- Re-ran the same harness against the patched worker at a harsher 5s task cadence: 126 tasks over 10+ minutes, no panic, `/metrics` healthy throughout.
- Added `TestRunHeartbeatAndWritesAreConcurrencySafe`, which floods data writes while heartbeats fire every millisecond. It panics within milliseconds on the old code and passes (including with `-race`) on the new code.
- `gofmt -l`, `go vet ./...`, and `go test ./... -count=1` all clean; `go test ./internal/worker/ -race` passes.

_Conversation: https://staging.warp.dev/conversation/39bc9ab0-e95f-4dc2-a407-8ba48a538501_
_Run: https://oz.staging.warp.dev/runs/019eb399-127f-7823-a778-133001ab7d95_

_This PR was generated with [Oz](https://warp.dev/oz)._
