### PR TITLE
fix(kubernetes): make task Job creation idempotent on AlreadyExists (DEVEX-882)

### DIFF
--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -50,6 +50,13 @@ const (
 	maxLogBytes = 1 << 20 // 1 MiB
 )
 
+// Tunables for waiting on stale task Job deletion before recreating. These are
+// package-level vars (not consts) so tests can shrink them and avoid real waits.
+var (
+	jobDeletionPollInterval = 200 * time.Millisecond
+	jobDeletionTimeout      = 30 * time.Second
+)
+
 // KubernetesBackendConfig holds configuration specific to the Kubernetes backend.
 type KubernetesBackendConfig struct {
 	WorkerID              string
@@ -282,7 +289,7 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 	}
 
 	log.Infof(ctx, "Creating Kubernetes Job %s in namespace %s", jobName, b.config.Namespace)
-	if _, err := b.clientset.BatchV1().Jobs(b.config.Namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {
+	if err := b.createTaskJob(ctx, job); err != nil {
 		return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonJobCreate, fmt.Errorf("failed to create Kubernetes Job: %w", err))
 	}
 
@@ -931,6 +938,65 @@ func (b *KubernetesBackend) readContainerLogs(ctx context.Context, podName, cont
 		return "", err
 	}
 	return string(data), nil
+}
+
+// createTaskJob creates the task Job idempotently.
+//
+// The task Job name is fully deterministic per execution, so an idled or
+// cancelled task that left its Job in place (cleanup is intentionally skipped on
+// context cancellation) makes the next dispatch of that same task collide on
+// create with an AlreadyExists error. When that happens we delete the stale Job,
+// wait until it is fully gone, and retry the create exactly once. Any other
+// create error is returned unchanged so the non-collision path behaves
+// identically to a plain Create.
+func (b *KubernetesBackend) createTaskJob(ctx context.Context, job *batchv1.Job) error {
+	_, err := b.clientset.BatchV1().Jobs(b.config.Namespace).Create(ctx, job, metav1.CreateOptions{})
+	if err == nil {
+		return nil
+	}
+	if !apierrors.IsAlreadyExists(err) {
+		return err
+	}
+
+	log.Infof(ctx, "Kubernetes Job %s already exists; deleting stale Job and retrying create", job.Name)
+	if delErr := b.deleteJob(ctx, job.Name); delErr != nil {
+		return fmt.Errorf("failed to delete stale Kubernetes Job %s before recreating: %w", job.Name, delErr)
+	}
+	if waitErr := b.waitForJobDeletion(ctx, job.Name); waitErr != nil {
+		return waitErr
+	}
+
+	_, err = b.clientset.BatchV1().Jobs(b.config.Namespace).Create(ctx, job, metav1.CreateOptions{})
+	return err
+}
+
+// waitForJobDeletion polls until the named Job is fully gone (NotFound). It
+// returns early if ctx is cancelled and errors out after a bounded timeout so a
+// stuck deletion never blocks task dispatch forever.
+func (b *KubernetesBackend) waitForJobDeletion(ctx context.Context, jobName string) error {
+	deadlineCtx, cancel := context.WithTimeout(ctx, jobDeletionTimeout)
+	defer cancel()
+
+	ticker := time.NewTicker(jobDeletionPollInterval)
+	defer ticker.Stop()
+
+	for {
+		_, err := b.clientset.BatchV1().Jobs(b.config.Namespace).Get(deadlineCtx, jobName, metav1.GetOptions{})
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-deadlineCtx.Done():
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("timed out waiting for stale Kubernetes Job %s to be deleted: deletion appears stuck", jobName)
+		case <-ticker.C:
+		}
+	}
 }
 
 func (b *KubernetesBackend) deleteJob(ctx context.Context, jobName string) error {

--- a/internal/worker/kubernetes_test.go
+++ b/internal/worker/kubernetes_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/warpdotdev/oz-agent-worker/internal/metrics"
 	"github.com/warpdotdev/oz-agent-worker/internal/types"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -888,6 +889,126 @@ func TestExecuteTaskUsesCopyInitContainersByDefault(t *testing.T) {
 	}
 	if taskSidecarMount.ReadOnly {
 		t.Fatal("expected task sidecar mount to remain writable on default path")
+	}
+}
+
+func TestExecuteTaskRecreatesStaleJobOnAlreadyExists(t *testing.T) {
+	jobName := sanitizeKubernetesJobName("task-1")
+	staleJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: "agents",
+		},
+	}
+	fakeClient := fake.NewSimpleClientset(staleJob)
+	jobWatch := watch.NewFake()
+	podWatch := watch.NewFake()
+	defer jobWatch.Stop()
+	defer podWatch.Stop()
+
+	var createCount int
+	var createdJob *batchv1.Job
+	fakeClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateActionImpl)
+		if !ok {
+			t.Fatalf("expected create action, got %T", action)
+		}
+		job, ok := createAction.GetObject().(*batchv1.Job)
+		if !ok {
+			t.Fatalf("expected Job object, got %T", createAction.GetObject())
+		}
+		createCount++
+		createdJob = job.DeepCopy()
+		// Fall through to the tracker: the first create collides with the seeded
+		// stale Job (AlreadyExists), the second succeeds after deletion.
+		return false, nil, nil
+	})
+	fakeClient.PrependWatchReactor("jobs", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			if createdJob == nil {
+				return
+			}
+			completedJob := createdJob.DeepCopy()
+			completedJob.Status.Conditions = []batchv1.JobCondition{
+				{
+					Type:   batchv1.JobComplete,
+					Status: corev1.ConditionTrue,
+				},
+			}
+			jobWatch.Modify(completedJob)
+		}()
+		return true, jobWatch, nil
+	})
+	fakeClient.PrependWatchReactor("pods", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		return true, podWatch, nil
+	})
+
+	backend := &KubernetesBackend{
+		config: KubernetesBackendConfig{
+			WorkerID:  "worker-123",
+			Namespace: "agents",
+		},
+		clientset: fakeClient,
+	}
+
+	err := backend.ExecuteTask(context.Background(), &TaskParams{
+		TaskID:      "task-1",
+		DockerImage: "ubuntu:22.04",
+		BaseArgs:    []string{"run"},
+	})
+	if err != nil {
+		t.Fatalf("expected ExecuteTask to recover from AlreadyExists, got %v", err)
+	}
+	if createCount != 2 {
+		t.Fatalf("expected exactly 2 create attempts (collide + recreate), got %d", createCount)
+	}
+}
+
+func TestExecuteTaskFailsWhenStaleJobDeletionStuck(t *testing.T) {
+	prevPoll, prevTimeout := jobDeletionPollInterval, jobDeletionTimeout
+	jobDeletionPollInterval = time.Millisecond
+	jobDeletionTimeout = 5 * time.Millisecond
+	defer func() {
+		jobDeletionPollInterval = prevPoll
+		jobDeletionTimeout = prevTimeout
+	}()
+
+	jobName := sanitizeKubernetesJobName("task-1")
+	staleJob := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      jobName,
+			Namespace: "agents",
+		},
+	}
+	fakeClient := fake.NewSimpleClientset(staleJob)
+
+	// The Job stays present forever, simulating a deletion that never completes.
+	fakeClient.PrependReactor("get", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		return true, staleJob.DeepCopy(), nil
+	})
+
+	backend := &KubernetesBackend{
+		config: KubernetesBackendConfig{
+			WorkerID:  "worker-123",
+			Namespace: "agents",
+		},
+		clientset: fakeClient,
+	}
+
+	err := backend.ExecuteTask(context.Background(), &TaskParams{
+		TaskID:      "task-1",
+		DockerImage: "ubuntu:22.04",
+		BaseArgs:    []string{"run"},
+	})
+	if err == nil {
+		t.Fatal("expected ExecuteTask to fail when stale Job deletion is stuck")
+	}
+	if _, reason := taskFailureLabels(err); reason != metrics.TaskFailureReasonJobCreate {
+		t.Fatalf("failure reason = %q, want %q", reason, metrics.TaskFailureReasonJobCreate)
+	}
+	if !strings.Contains(err.Error(), "deletion appears stuck") {
+		t.Fatalf("expected stuck-deletion detail, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Root cause

The task Job name is fully deterministic per execution: `sanitizeKubernetesJobName(taskExecutionID(params))` produces `oz-task-<sanitized-taskID>-<hash>`, where the hash is the first 8 bytes of sha256. So the same logical task always maps to the same Job name.

Cleanup is deferred and intentionally skipped on context cancellation (the *"Leaving Kubernetes Job ... in place after task context cancellation"* branch), so an idled/cancelled task **orphans its deterministically-named Job**. With the 24h TTL, the next dispatch of that same task collides on create.

At the create site, every error from `Jobs().Create(...)` — including a 409 `AlreadyExists` — was treated as a fatal `JobCreate` backend failure, with no `apierrors.IsAlreadyExists` handling. The result was the intermittent, then permanent, failure:

```
Failed to execute task: failed to create Kubernetes Job: jobs.batch "oz-task-<id>-<hash>" already exists
```

## Fix

- Replace the raw `Create` at the create site with `createTaskJob(ctx, job)`, which:
  - calls `Create`; returns `nil` on success,
  - returns the error unchanged if it is **not** `apierrors.IsAlreadyExists`,
  - on `AlreadyExists`, deletes the stale Job via the existing `deleteJob` helper (background propagation), waits until it is fully gone, then retries `Create` **exactly once**.
- Add a bounded `waitForJobDeletion(ctx, jobName)` that polls `Jobs().Get` until `apierrors.IsNotFound`, returns early on `ctx.Done()`, and errors out after a bounded timeout (30s, 200ms poll) with a clear *"deletion appears stuck"* message — never looping forever. The caller wraps a stuck deletion as a `JobCreate` backend failure so it stays observable.
- Poll interval / timeout are package-level vars (not consts) so tests can shrink them.

The Job-name scheme is unchanged and the non-collision path behaves identically.

## Tests

- `TestExecuteTaskRecreatesStaleJobOnAlreadyExists`: seeds a Job with the deterministic name and asserts `ExecuteTask` now succeeds (stale Job deleted + recreated, **exactly 2 create attempts**).
- `TestExecuteTaskFailsWhenStaleJobDeletionStuck`: with a get-reactor that always reports the Job present (and shrunk timeouts), asserts the failure reason is `metrics.TaskFailureReasonJobCreate` and the message mentions the deletion being stuck.

Validated locally: `go build ./...`, `go vet ./internal/worker/...`, `gofmt -l internal/worker`, and `go test ./internal/worker/...` are all clean/green.

Closes [DEVEX-882](https://linear.app/phantom-labs/issue/DEVEX-882).

🤖 Generated with [Claude Code](https://claude.com/claude-code)