### PR TITLE
Fix Docker sidecar volume names for registry refs with ports

### DIFF
--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"regexp"
 	"strings"
 	"time"
 
@@ -21,6 +22,9 @@ import (
 )
 
 const dockerHubAuthConfigKey = "https://index.docker.io/v1/"
+
+// invalidVolumeNameChars matches characters not allowed in Docker volume names.
+var invalidVolumeNameChars = regexp.MustCompile(`[^a-zA-Z0-9_.-]`)
 
 // DockerBackendConfig holds configuration specific to the Docker backend.
 type DockerBackendConfig struct {
@@ -514,8 +518,10 @@ func sanitizeVolumeName(imageName, digest string) string {
 		repoName = imageName
 	}
 
-	// Sanitize the repository name for use in volume name
-	baseName := strings.ReplaceAll(repoName, "/", "-")
+	// Sanitize the repository name for use in volume name. Docker volume names
+	// only allow [a-zA-Z0-9_.-], so registry hosts with ports (e.g.
+	// localhost:5000/warp-agent) must have their colons replaced too.
+	baseName := invalidVolumeNameChars.ReplaceAllString(repoName, "-")
 
 	// digest format is typically "sha256:abc123..."
 	parts := strings.Split(digest, ":")

--- a/internal/worker/docker_volume_name_test.go
+++ b/internal/worker/docker_volume_name_test.go
@@ -1,0 +1,46 @@
+package worker
+
+import "testing"
+
+func TestSanitizeVolumeName(t *testing.T) {
+	tests := []struct {
+		name      string
+		imageName string
+		digest    string
+		want      string
+	}{
+		{
+			name:      "docker hub image",
+			imageName: "warpdotdev/warp-agent:latest-dev",
+			digest:    "sha256:cdd2970ebf33dea820d96c39246d0db275f1e33965e9b65381e778eb77a7a1af",
+			want:      "warpdotdev-warp-agent-cdd2970ebf33",
+		},
+		{
+			name:      "registry host with port",
+			imageName: "localhost:5000/warp-agent:pr120",
+			digest:    "sha256:cdd2970ebf33dea820d96c39246d0db275f1e33965e9b65381e778eb77a7a1af",
+			want:      "localhost-5000-warp-agent-cdd2970ebf33",
+		},
+		{
+			name:      "registry host with port and nested repo",
+			imageName: "registry.example.com:8443/team/agent:v1",
+			digest:    "sha256:abcdef0123456789",
+			want:      "registry.example.com-8443-team-agent-abcdef012345",
+		},
+		{
+			name:      "malformed digest falls back to base name plus digest",
+			imageName: "warpdotdev/warp-agent",
+			digest:    "not-a-digest",
+			want:      "warpdotdev-warp-agent-not-a-digest",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeVolumeName(tt.imageName, tt.digest)
+			if got != tt.want {
+				t.Errorf("sanitizeVolumeName(%q, %q) = %q, want %q", tt.imageName, tt.digest, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
The Docker backend derives sidecar volume names from the image repository name but only replaces `/` characters. Image refs whose registry host includes a port (e.g. `localhost:5000/warp-agent:pr120`) keep the `:` and volume creation fails:

```
create localhost:5000-warp-agent-cdd2970ebf33: "localhost:5000-warp-agent-cdd2970ebf33" includes
invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed
```

This replaces every character outside `[a-zA-Z0-9_.-]` when building the volume name, and adds unit tests covering port-qualified registry refs.

## Context
Found while validating warpdotdev/warp-agent-docker#120 end-to-end against a local docker-backend Oz stack (`warp-server/script/oz-local --worker-backend docker`), where locally built sidecar images are served from a `localhost:5000` registry. Any self-hosted worker pulling sidecars from a port-qualified private registry would hit the same failure.

## Validation
- `go test ./internal/worker/ -run TestSanitizeVolumeName` passes.
- E2E: with this fix, tasks using `localhost:5000/warp-agent:pr120` as the sidecar image create the volume `localhost-5000-warp-agent-cdd2970ebf33` and run to completion on the docker backend.

_Conversation: https://staging.warp.dev/conversation/b7db9360-e563-44c7-b2b2-a6c30dbc7645_
_Run: https://oz.staging.warp.dev/runs/019ebca1-59ed-7e05-8fa2-042278a8e219_

_This PR was generated with [Oz](https://warp.dev/oz)._
