### PR TITLE
Ensure `oz_worker_tasks_max_concurrent` is primed at startup.

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -275,6 +275,7 @@ func shouldInitTraces() bool {
 func primeInstruments(ctx context.Context, set *instruments) {
 	set.connected.Record(ctx, 0)
 	set.tasksActive.Add(ctx, 0)
+	set.tasksMaxConcurrent.Record(ctx, 0)
 	set.tasksClaimed.Add(ctx, 0)
 	set.tasksRejected.Add(ctx, 0,
 		metric.WithAttributes(attribute.String("reason", RejectReasonAtCapacity)),

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -171,6 +171,30 @@ func TestSetConnectedEmitsGauge(t *testing.T) {
 	}
 }
 
+func TestSetMaxConcurrentEmitsGauge(t *testing.T) {
+	reader := withTestReader(t, Config{WorkerID: "w1", Backend: "docker"})
+
+	SetMaxConcurrent(0)
+	rm := collect(t, reader)
+
+	maxConcurrent := findMetric(t, rm, "oz_worker_tasks_max_concurrent")
+	g, ok := maxConcurrent.Data.(metricdata.Gauge[int64])
+	if !ok {
+		t.Fatalf("expected Gauge[int64], got %T", maxConcurrent.Data)
+	}
+	if len(g.DataPoints) != 1 || g.DataPoints[0].Value != 0 {
+		t.Errorf("max concurrent gauge = %+v, want value 0", g.DataPoints)
+	}
+
+	SetMaxConcurrent(4)
+	rm = collect(t, reader)
+	maxConcurrent = findMetric(t, rm, "oz_worker_tasks_max_concurrent")
+	g = maxConcurrent.Data.(metricdata.Gauge[int64])
+	if len(g.DataPoints) != 1 || g.DataPoints[0].Value != 4 {
+		t.Errorf("max concurrent gauge = %+v, want value 4", g.DataPoints)
+	}
+}
+
 func TestRecordTaskRejectedTagsReason(t *testing.T) {
 	reader := withTestReader(t, Config{WorkerID: "w1", Backend: "docker"})
 
@@ -223,6 +247,7 @@ func TestPrimeInstrumentsExposesAllSeriesAtStartup(t *testing.T) {
 	want := []string{
 		"oz_worker_connected",
 		"oz_worker_tasks_active",
+		"oz_worker_tasks_max_concurrent",
 		"oz_worker_tasks_rejected_total",
 		"oz_worker_tasks_completed_total",
 		"oz_worker_task_failures_total",


### PR DESCRIPTION
## Description

Prime `oz_worker_tasks_max_concurrent` at metrics initialization so the series is available immediately, including when the worker uses the default unlimited concurrency value of `0`. Normal startup still records the resolved worker configuration afterward; this adds defense-in-depth and regression coverage for the gauge.

## Testing

- `go test ./internal/metrics`

Co-Authored-By: Oz <oz-agent@warp.dev>