### PR TITLE
Set CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1 for claude harness cloud agents

### DIFF
--- a/internal/worker/direct.go
+++ b/internal/worker/direct.go
@@ -354,8 +354,9 @@ func parseEnvFile(path string) (map[string]string, error) {
 }
 
 type harnessConfig struct {
-	configEnvVar string
-	configDir    string
+	configEnvVar      string
+	configDir         string
+	additionalEnvVars []string // Additional fixed environment variables to set for this harness.
 }
 
 // Used for setting configEnvVar to "workspaceDir/configDir"
@@ -363,6 +364,11 @@ var harnessConfigs = map[string]harnessConfig{
 	"claude": {
 		configEnvVar: "CLAUDE_CONFIG_DIR",
 		configDir:    ".claude",
+		// Disable alternate-screen mode so Claude Code output is captured in
+		// the scrollback buffer rather than rendered as a full-screen TUI. Without
+		// this, completed cloud agent sessions appear to contain only a single
+		// CLI line instead of the full conversation transcript.
+		additionalEnvVars: []string{"CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1"},
 	},
 	"codex": {
 		configEnvVar: "CODEX_HOME",
@@ -385,5 +391,7 @@ func harnessEnvVars(workspaceDir string, params *TaskParams) []string {
 	if !ok {
 		return nil
 	}
-	return []string{fmt.Sprintf("%s=%s", config.configEnvVar, filepath.Join(workspaceDir, config.configDir))}
+	result := []string{fmt.Sprintf("%s=%s", config.configEnvVar, filepath.Join(workspaceDir, config.configDir))}
+	result = append(result, config.additionalEnvVars...)
+	return result
 }

--- a/internal/worker/direct_test.go
+++ b/internal/worker/direct_test.go
@@ -23,7 +23,8 @@ func TestDirectHarnessEnv(t *testing.T) {
 			name:    "claude",
 			harness: stringPtr("claude"),
 			want: map[string]string{
-				"CLAUDE_CONFIG_DIR": filepath.Join(workspaceDir, ".claude"),
+				"CLAUDE_CONFIG_DIR":                    filepath.Join(workspaceDir, ".claude"),
+				"CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN": "1",
 			},
 		},
 		{


### PR DESCRIPTION
## Why

Claude Code recently changed its default behavior to use an alternate screen (full-screen TUI mode). When a cloud agent runs with the `claude` harness, this caused completed sessions to display only a single CLI line instead of the full conversation transcript — because our block-saving logic doesn't capture alt-screen output.

This was reported as a production blocker in REMOTE-1992 and is directly impacting SE demo work with a prospect exclusively using Claude Code as a cloud agent harness.

## What

Set `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` in the environment whenever the `claude` harness is used, so Claude Code writes its output to the normal scrollback buffer and the full conversation is captured and displayed.

**Implementation:** Extended the `harnessConfig` struct with an `additionalEnvVars []string` field so harnesses can declare static environment variables alongside their config directory setting. The `harnessEnvVars` function now appends these to its return slice. This keeps the pattern extensible for future per-harness env var needs.

Updated `TestDirectHarnessEnv` to assert `CLAUDE_CODE_DISABLE_ALTERNATE_SCREEN=1` is present for the `claude` harness.

_Conversation: https://staging.warp.dev/conversation/39b61ab4-8633-497b-b2a3-cadf15246ccd_
_Run: https://oz.staging.warp.dev/runs/019f00bf-6c8a-7b67-9120-7912eeb7fba6_
_This PR was generated with [Oz](https://warp.dev/oz)._
