### PR TITLE
k8s: support custom coding CLI sidecar image via coding_cli_sidecars config

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,16 @@ Notes:
 - `unschedulable_timeout` controls how long a Pod may remain unschedulable before the task is failed early; it defaults to `30s`, and `0s` disables that fail-fast behavior
 - `image_pull_policy` defaults to `IfNotPresent`
 - `sidecar_image` overrides the warp-agent sidecar image reference sent by the server (e.g. `docker.io/warpdotdev/warp-agent:latest`); set this when cluster nodes cannot pull directly from Docker Hub and must use an internal registry mirror or pull-through cache instead. This only affects the warp-agent sidecar (mounted at `/agent`), not any additional sidecars. When using this override, you are responsible for keeping your mirror in sync with `docker.io/warpdotdev/warp-agent` — the server normally sends the correct version-matched image per task, so a stale mirror may cause version incompatibility
+- `coding_cli_sidecars` maps a harness config name (e.g. `claude`, `codex`) to a custom Docker image that will be mounted as the coding CLI sidecar for runs using that harness. When set, the worker replaces the server-provided sidecar image (or injects a new entry if the server did not send one) at the standard mount path `/mnt/{harness}-cli-sidecar`. Use this when your cluster uses a custom or internal Claude Code binary wrapper instead of the Warp-provided image. Example:
+
+```yaml
+backend:
+  kubernetes:
+    coding_cli_sidecars:
+      claude: "registry.internal.example.com/my-claude-wrapper:v1"
+```
+
+  The custom image must have the harness binary reachable in the path that the Warp agent entrypoint scans (typically `/usr/local/bin` inside the sidecar image). `claude` must be in `PATH` when the harness process is invoked
 - by default, the Kubernetes backend materializes sidecars with root init containers into `emptyDir` volumes, matching the existing behavior
 - set `use_image_volumes: true` to opt into native image volumes for sidecars; in that mode, sidecar mounts are read-only and Kubernetes/runtime support for the built-in `ImageVolume` Pod volume source is required
 - Kubernetes `1.35+` is the recommended and tested target for `use_image_volumes: true`; Kubernetes `1.33`-`1.34` may work if `ImageVolume` is enabled and the container runtime supports image volumes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,14 @@ type KubernetesConfig struct {
 	TTLSecondsAfterFinish *int32            `yaml:"ttl_seconds_after_finished"`
 	WorkspaceSizeLimit    string            `yaml:"workspace_size_limit"`
 	UnschedulableTimeout  *string           `yaml:"unschedulable_timeout"`
+	// CodingCLISidecars maps harness config name (e.g. "claude", "codex") to a custom
+	// Docker image. When set, the worker overrides the server-provided sidecar image for
+	// that harness (or injects a new sidecar entry if the server did not send one),
+	// mounting it at /mnt/{harness}-cli-sidecar. Use this to bring your own Claude Code
+	// wrapper or custom harness binary instead of the Warp-provided sidecar image.
+	// The custom image must place the harness binary in the path where the Warp agent
+	// entrypoint expects it (e.g. /usr/local/bin for most sidecar layouts).
+	CodingCLISidecars map[string]string `yaml:"coding_cli_sidecars"`
 	// PodTemplate holds a raw Kubernetes PodSpec that is merged with the worker's
 	// required fields at runtime. Declarative task Job configuration such as
 	// serviceAccountName, imagePullSecrets, node selectors, tolerations,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -56,6 +56,37 @@ backend:
 	}
 }
 
+func TestLoadKubernetesCodingCLISidecars(t *testing.T) {
+	path := writeTestConfig(t, `
+worker_id: "k8s-worker"
+backend:
+  kubernetes:
+    namespace: "agents"
+    coding_cli_sidecars:
+      claude: "registry.internal.example.com/my-claude-wrapper:v1"
+      codex: "registry.internal.example.com/my-codex-wrapper:v2"
+`)
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Backend.Kubernetes == nil {
+		t.Fatal("expected kubernetes backend to be set")
+	}
+	sidecars := cfg.Backend.Kubernetes.CodingCLISidecars
+	if len(sidecars) != 2 {
+		t.Fatalf("coding_cli_sidecars count = %d, want 2", len(sidecars))
+	}
+	if sidecars["claude"] != "registry.internal.example.com/my-claude-wrapper:v1" {
+		t.Errorf("claude = %q, want %q", sidecars["claude"], "registry.internal.example.com/my-claude-wrapper:v1")
+	}
+	if sidecars["codex"] != "registry.internal.example.com/my-codex-wrapper:v2" {
+		t.Errorf("codex = %q, want %q", sidecars["codex"], "registry.internal.example.com/my-codex-wrapper:v2")
+	}
+}
+
 func TestLoadMinimalConfig(t *testing.T) {
 	path := writeTestConfig(t, `
 worker_id: "minimal"

--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -69,6 +69,10 @@ type KubernetesBackendConfig struct {
 	TTLSecondsAfterFinish *int32
 	WorkspaceSizeLimit    *resource.Quantity
 	UnschedulableTimeout  *time.Duration
+	// CodingCLISidecars maps harness config name (e.g. "claude", "codex") to a custom
+	// Docker image for the coding CLI sidecar. When non-empty for a task's harness,
+	// the worker overrides or injects the sidecar at /mnt/{harness}-cli-sidecar.
+	CodingCLISidecars map[string]string
 	// TaskEnv contains runtime-only env overrides from CLI -e/--env. Declarative
 	// task container env in file or Helm config should be set in PodTemplate.
 	TaskEnv map[string]string

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
+	"strings"
 	"sync"
 	"time"
 
@@ -493,6 +494,37 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		})
 	}
 	sidecars = append(sidecars, assignment.AdditionalSidecars...)
+
+	// Apply worker-configured coding CLI sidecar overrides.
+	// For each harness entry in the worker's coding_cli_sidecars config, replace the
+	// server-provided sidecar image at /mnt/{harness}-cli-sidecar or inject a new entry
+	// when the server did not send one (e.g. because no Warp-side image is configured).
+	if w.config.Kubernetes != nil && len(w.config.Kubernetes.CodingCLISidecars) > 0 {
+		if task != nil && task.AgentConfigSnapshot != nil &&
+			task.AgentConfigSnapshot.Harness != nil &&
+			task.AgentConfigSnapshot.Harness.Type != nil {
+			harnessType := strings.TrimSpace(*task.AgentConfigSnapshot.Harness.Type)
+			if customImage, ok := w.config.Kubernetes.CodingCLISidecars[harnessType]; ok && customImage != "" {
+				mountPath := fmt.Sprintf("/mnt/%s-cli-sidecar", harnessType)
+				overridden := false
+				for i, s := range sidecars {
+					if s.MountPath == mountPath {
+						log.Infof(w.ctx, "Overriding server coding CLI sidecar %s with configured image %s for harness %s", s.Image, customImage, harnessType)
+						sidecars[i].Image = customImage
+						overridden = true
+						break
+					}
+				}
+				if !overridden {
+					log.Infof(w.ctx, "Injecting configured coding CLI sidecar %s for harness %s at %s", customImage, harnessType, mountPath)
+					sidecars = append(sidecars, types.SidecarMount{
+						Image:     customImage,
+						MountPath: mountPath,
+					})
+				}
+			}
+		}
+	}
 
 	return &TaskParams{
 		TaskID:      assignment.TaskID,

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -573,6 +573,137 @@ func TestPrepareTaskParamsSidecarImageOverride(t *testing.T) {
 	})
 }
 
+func TestPrepareTaskParamsCodingCLISidecarOverride(t *testing.T) {
+	newWorker := func(codingCLISidecars map[string]string) *Worker {
+		return &Worker{
+			ctx: context.Background(),
+			config: Config{
+				Kubernetes: &KubernetesBackendConfig{
+					CodingCLISidecars: codingCLISidecars,
+				},
+			},
+		}
+	}
+
+	strPtr := func(s string) *string { return &s }
+
+	// harnessTask builds a task whose agent config snapshot advertises the given
+	// harness type. A nil harnessType produces a snapshot with a harness whose
+	// Type pointer is nil.
+	harnessTask := func(harnessType *string) *types.Task {
+		return &types.Task{
+			ID: "task-1",
+			AgentConfigSnapshot: &types.AmbientAgentConfig{
+				Harness: &types.Harness{Type: harnessType},
+			},
+		}
+	}
+
+	findSidecar := func(sidecars []types.SidecarMount, mountPath string) (types.SidecarMount, bool) {
+		for _, s := range sidecars {
+			if s.MountPath == mountPath {
+				return s, true
+			}
+		}
+		return types.SidecarMount{}, false
+	}
+
+	t.Run("overrides server-provided coding CLI sidecar at mount path", func(t *testing.T) {
+		w := newWorker(map[string]string{"claude": "registry.internal/my-claude:v1"})
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID:       "task-1",
+			Task:         harnessTask(strPtr("claude")),
+			SidecarImage: "docker.io/warpdotdev/warp-agent:latest",
+			AdditionalSidecars: []types.SidecarMount{
+				{Image: "docker.io/warpdotdev/claude-cli:latest", MountPath: "/mnt/claude-cli-sidecar", ReadWrite: true},
+			},
+		})
+
+		got, ok := findSidecar(params.Sidecars, "/mnt/claude-cli-sidecar")
+		if !ok {
+			t.Fatalf("expected coding CLI sidecar at /mnt/claude-cli-sidecar, got %+v", params.Sidecars)
+		}
+		if got.Image != "registry.internal/my-claude:v1" {
+			t.Errorf("image = %q, want %q", got.Image, "registry.internal/my-claude:v1")
+		}
+		// Overriding only replaces the image; other mount options are preserved.
+		if !got.ReadWrite {
+			t.Error("expected ReadWrite to be preserved on overridden sidecar")
+		}
+		// No new sidecar should be injected: the /agent + claude sidecars remain.
+		if len(params.Sidecars) != 2 {
+			t.Fatalf("sidecar count = %d, want 2: %+v", len(params.Sidecars), params.Sidecars)
+		}
+		// The warp-agent sidecar at /agent must be untouched.
+		if agent, ok := findSidecar(params.Sidecars, "/agent"); !ok || agent.Image != "docker.io/warpdotdev/warp-agent:latest" {
+			t.Errorf("agent sidecar = %+v, want image docker.io/warpdotdev/warp-agent:latest", agent)
+		}
+	})
+
+	t.Run("injects coding CLI sidecar when server did not provide one", func(t *testing.T) {
+		w := newWorker(map[string]string{"claude": "registry.internal/my-claude:v1"})
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID: "task-1",
+			Task:   harnessTask(strPtr("claude")),
+		})
+
+		got, ok := findSidecar(params.Sidecars, "/mnt/claude-cli-sidecar")
+		if !ok {
+			t.Fatalf("expected injected coding CLI sidecar at /mnt/claude-cli-sidecar, got %+v", params.Sidecars)
+		}
+		if got.Image != "registry.internal/my-claude:v1" {
+			t.Errorf("image = %q, want %q", got.Image, "registry.internal/my-claude:v1")
+		}
+	})
+
+	t.Run("trims whitespace from harness type", func(t *testing.T) {
+		w := newWorker(map[string]string{"claude": "registry.internal/my-claude:v1"})
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID: "task-1",
+			Task:   harnessTask(strPtr("  claude  ")),
+		})
+		if _, ok := findSidecar(params.Sidecars, "/mnt/claude-cli-sidecar"); !ok {
+			t.Fatalf("expected coding CLI sidecar at /mnt/claude-cli-sidecar, got %+v", params.Sidecars)
+		}
+	})
+
+	t.Run("no override when harness type not configured", func(t *testing.T) {
+		w := newWorker(map[string]string{"claude": "registry.internal/my-claude:v1"})
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID: "task-1",
+			Task:   harnessTask(strPtr("codex")),
+		})
+		if _, ok := findSidecar(params.Sidecars, "/mnt/codex-cli-sidecar"); ok {
+			t.Error("did not expect coding CLI sidecar for unconfigured harness")
+		}
+		if _, ok := findSidecar(params.Sidecars, "/mnt/claude-cli-sidecar"); ok {
+			t.Error("did not expect claude coding CLI sidecar for codex harness")
+		}
+	})
+
+	t.Run("no override when configured image is empty", func(t *testing.T) {
+		w := newWorker(map[string]string{"claude": ""})
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID: "task-1",
+			Task:   harnessTask(strPtr("claude")),
+		})
+		if _, ok := findSidecar(params.Sidecars, "/mnt/claude-cli-sidecar"); ok {
+			t.Error("did not expect coding CLI sidecar when configured image is empty")
+		}
+	})
+
+	t.Run("no override when task has no harness snapshot", func(t *testing.T) {
+		w := newWorker(map[string]string{"claude": "registry.internal/my-claude:v1"})
+		params := w.prepareTaskParams(&types.TaskAssignmentMessage{
+			TaskID: "task-1",
+			Task:   &types.Task{ID: "task-1"},
+		})
+		if len(params.Sidecars) != 0 {
+			t.Errorf("expected no sidecars when task has no harness, got %d: %+v", len(params.Sidecars), params.Sidecars)
+		}
+	})
+}
+
 func TestPrepareTaskParamsTeamShareConditional(t *testing.T) {
 	newWorker := func() *Worker {
 		return &Worker{

--- a/main.go
+++ b/main.go
@@ -191,6 +191,7 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 			useImageVolumes       bool
 			preflightImage        string
 			sidecarImage          string
+			codingCLISidecars     map[string]string
 			setupCmd              string
 			teardownCmd           string
 			extraLabels           map[string]string
@@ -211,6 +212,7 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 			useImageVolumes = kc.UseImageVolumes
 			preflightImage = kc.PreflightImage
 			sidecarImage = kc.SidecarImage
+			codingCLISidecars = copyStringMap(kc.CodingCLISidecars)
 			setupCmd = kc.SetupCommand
 			teardownCmd = kc.TeardownCommand
 			extraLabels = copyStringMap(kc.ExtraLabels)
@@ -253,6 +255,7 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 			UseImageVolumes:       useImageVolumes,
 			PreflightImage:        preflightImage,
 			SidecarImage:          sidecarImage,
+			CodingCLISidecars:     codingCLISidecars,
 			SetupCommand:          setupCmd,
 			TeardownCommand:       teardownCmd,
 			NoCleanup:             noCleanup,

--- a/main_test.go
+++ b/main_test.go
@@ -196,3 +196,37 @@ func TestMergeConfigKubernetesAllowsZeroUnschedulableTimeout(t *testing.T) {
 		t.Fatalf("UnschedulableTimeout = %v, want 0", wc.Kubernetes.UnschedulableTimeout)
 	}
 }
+
+func TestMergeConfigKubernetesCodingCLISidecars(t *testing.T) {
+	resetCLIForTest()
+	t.Cleanup(resetCLIForTest)
+
+	fileConfig := &config.FileConfig{
+		WorkerID: "worker-123",
+		Backend: config.BackendConfig{
+			Kubernetes: &config.KubernetesConfig{
+				CodingCLISidecars: map[string]string{
+					"claude": "registry.internal/my-claude:v1",
+				},
+			},
+		},
+	}
+
+	wc, err := mergeConfig(fileConfig)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if wc.Kubernetes == nil {
+		t.Fatal("expected kubernetes backend config")
+	}
+	if got := wc.Kubernetes.CodingCLISidecars["claude"]; got != "registry.internal/my-claude:v1" {
+		t.Errorf("CodingCLISidecars[claude] = %q, want %q", got, "registry.internal/my-claude:v1")
+	}
+
+	// mergeConfig must copy the map rather than alias the file config's map, so a
+	// later mutation of the file config does not leak into the merged worker config.
+	fileConfig.Backend.Kubernetes.CodingCLISidecars["claude"] = "mutated"
+	if got := wc.Kubernetes.CodingCLISidecars["claude"]; got != "registry.internal/my-claude:v1" {
+		t.Errorf("expected merged config to be insulated from file config mutation, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a new `coding_cli_sidecars` config option to the Kubernetes backend that lets self-hosted workers specify a custom Docker image for a harness's coding CLI sidecar (e.g. Claude Code or Codex). This is a customer requirement for teams like IMC who want to use their own Claude Code binary wrapper instead of the Warp-provided sidecar image.

## Motivation

The existing `sidecar_image` config only overrides the Warp agent sidecar (at `/agent`). For coding CLI harnesses (Claude Code, Codex), the binary is delivered via an additional sidecar mounted at `/mnt/{harness}-cli-sidecar`. Previously there was no way for a self-hosted k8s operator to bring their own harness binary — it was fully server-controlled via `selfhosted.coding_cli_sidecars.{harness}` in warp-server config.

## Changes

- `internal/config/config.go`: Adds `CodingCLISidecars map[string]string` (yaml: `coding_cli_sidecars`) to `KubernetesConfig`
- `internal/worker/kubernetes.go`: Adds `CodingCLISidecars` to `KubernetesBackendConfig`
- `main.go`: Wires the new config field through `mergeConfig` → `KubernetesBackendConfig`
- `internal/worker/worker.go`: In `prepareTaskParams`, after building the sidecars list, overrides or injects the coding CLI sidecar when the task's harness matches a `coding_cli_sidecars` entry
- `README.md`: Documents the new config option with an example

## Behavior

When a task arrives using a non-oz harness (e.g. `claude`), the worker:
1. **Overrides** the server-provided image at `/mnt/{harness}-cli-sidecar` if one was sent, OR
2. **Injects** a new sidecar entry if the server did not include one

Example worker config:
```yaml
backend:
  kubernetes:
    coding_cli_sidecars:
      claude: "registry.internal.example.com/my-claude-wrapper:v1"
```

The custom image must have the harness binary (`claude`) reachable in PATH at runtime — the Warp agent entrypoint adds the sidecar's directories to PATH automatically.

_Conversation: https://staging.warp.dev/conversation/b3fa41e8-1525-4896-b6be-ac6f9e0a9b5b_
_Run: https://oz.staging.warp.dev/runs/019f0530-f7a6-7586-b838-91788050ef50_

_This PR was generated with [Oz](https://warp.dev/oz)._
