### PR TITLE
Mirror released image to GCP Artifact Registry [REMOTE-2031]

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -120,6 +120,11 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: namespace-profile-ubuntu-small
+    permissions:
+      contents: read
+      # Required to mint a GitHub OIDC token for authenticating to GCP via
+      # Workload Identity Federation when mirroring the image to Artifact Registry.
+      id-token: write
     outputs:
       image: "warpdotdev/oz-agent-worker@${{ steps.push.outputs.digest }}"
       tagged_image: ${{ steps.image-tags.outputs.primary }}
@@ -179,3 +184,40 @@ jobs:
             org.opencontainers.image.revision=${{ github.sha }}
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
             org.opencontainers.image.version=${{ inputs.version != '' && inputs.version || (inputs.docker_tag != '' && inputs.docker_tag || github.sha) }}
+
+      # Mirror the published image into the GCP Artifact Registry repo that also
+      # hosts warp-agent and the *-sidecar images, so consumers (e.g. self-hosted
+      # / enterprise) can pull the worker from the GCP mirror, not just Docker Hub.
+      # Only runs for tagged releases, since that's when the image is pushed.
+      - name: Authenticate to GCP
+        if: inputs.docker_tag != ''
+        id: gcp_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: astral-field-294621
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+          request_reason: Mirror oz-agent-worker image to the warp-public-images Artifact Registry
+
+      - name: Log in to Artifact Registry
+        if: inputs.docker_tag != ''
+        uses: docker/login-action@v4
+        with:
+          registry: us-east4-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp_auth.outputs.auth_token }}
+
+      - name: Mirror image to GCP Artifact Registry
+        if: inputs.docker_tag != ''
+        env:
+          DOCKER_TAG: ${{ inputs.docker_tag }}
+          PUBLISH_LATEST: ${{ inputs.publish_latest }}
+          # Same registry/repo used by warp-agent and the *-sidecar images.
+          GCP_IMAGE: us-east4-docker.pkg.dev/astral-field-294621/warp-public-images/oz-agent-worker
+        run: |
+          # Copy the multi-architecture manifest list from Docker Hub to the GCP
+          # mirror without rebuilding, preserving the exact digest.
+          tags=("--tag" "${GCP_IMAGE}:${DOCKER_TAG}")
+          if [ "$PUBLISH_LATEST" = "true" ]; then
+            tags+=("--tag" "${GCP_IMAGE}:latest")
+          fi
+          docker buildx imagetools create "${tags[@]}" "warpdotdev/oz-agent-worker:${DOCKER_TAG}"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,15 @@ docker pull warpdotdev/oz-agent-worker@sha256:<digest>
 
 `latest` is updated to the same image when a release is published, but it is a moving tag intended for quick testing only.
 
+Each release is also mirrored to a public GCP Artifact Registry repo, alongside the `warp-agent` and `*-sidecar` images. Pull from the mirror when you prefer not to depend on Docker Hub (e.g. some self-hosted / enterprise environments):
+
+```bash
+docker pull us-east4-docker.pkg.dev/astral-field-294621/warp-public-images/oz-agent-worker:v2026-06-01-10-09-37
+docker pull us-east4-docker.pkg.dev/astral-field-294621/warp-public-images/oz-agent-worker:latest
+```
+
+The mirror carries the same immutable timestamp tags (and `latest`) as Docker Hub, and the image is byte-for-byte identical (same digest).
+
 ### Direct
 
 The direct backend executes tasks directly on the host instead of inside Docker or Kubernetes. It requires the `oz` CLI to be available on `PATH` (or configured explicitly with `backend.direct.oz_path`) and stores per-task workspaces under `backend.direct.workspace_root` (default: `/var/lib/oz/workspaces`).


### PR DESCRIPTION
## Summary

Mirrors the released `oz-agent-worker` container image to GCP alongside `warp-agent` and the `*-sidecar` images (REMOTE-2031).

Previously the worker image was only published to Docker Hub. The `warp-agent` and `*-sidecar` images are already mirrored to a public GCP Artifact Registry repo (`warp-public-images`); this adds `oz-agent-worker` to that same mirror so consumers (e.g. self-hosted / enterprise) can pull the worker from the GCP mirror, not just Docker Hub.

## What changed

`.github/workflows/build_release.yml` (the `docker` job):

- Added `id-token: write` permission so the job can mint a GitHub OIDC token.
- After the existing Docker Hub build/push, added steps to authenticate to GCP via Workload Identity Federation (same provider used by the sidecar release workflow) and log in to `us-east4-docker.pkg.dev`.
- Added a mirror step that uses `docker buildx imagetools create` to copy the just-published multi-arch manifest from Docker Hub to `us-east4-docker.pkg.dev/astral-field-294621/warp-public-images/oz-agent-worker`, preserving the exact digest. It mirrors the immutable timestamp tag and (when applicable) `latest`.
- All mirror steps are gated on `inputs.docker_tag != ''`, so they only run for tagged releases (when the image is actually pushed).

`README.md`: documented pulling the worker from the GCP mirror.

## Dependency / rollout ordering

The mirror step requires the IAM writer grant added in the companion warp-terraform PR (`warpdotdev/warp-terraform#1240`). That terraform change must be applied **before** this merges to `main`, otherwise the mirror step will fail to authenticate. The Docker Hub push happens before the mirror step, so the primary release path is unaffected even if the mirror step fails.

## Verification

Once both changes are live, the next release will publish the worker to the mirror. Confirm with:

```bash
docker pull us-east4-docker.pkg.dev/astral-field-294621/warp-public-images/oz-agent-worker:latest
```


---
_Conversation: https://staging.warp.dev/conversation/471d8b43-baef-48dc-9b3e-9b05662e5d2b_
_Run: https://oz.staging.warp.dev/runs/019f1459-5ace-7e98-b24d-5f7c29ccd9f2_

_This PR was generated with [Oz](https://warp.dev/oz)._
