### PR TITLE
Mirror release image to Artifact Registry

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -69,7 +69,7 @@ jobs:
             goarch: arm64
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       
       - name: Install Go
         uses: actions/setup-go@v6
@@ -120,12 +120,34 @@ jobs:
   docker:
     name: Build and push Docker image
     runs-on: namespace-profile-ubuntu-small
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       image: "warpdotdev/oz-agent-worker@${{ steps.push.outputs.digest }}"
       tagged_image: ${{ steps.image-tags.outputs.primary }}
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
+
+      - name: Authenticate to GCP
+        # Only authenticate when we are actually pushing (docker_tag set). The
+        # no-push local-build path skips Artifact Registry entirely.
+        if: inputs.docker_tag != ''
+        id: gcp_auth
+        uses: google-github-actions/auth@v3
+        with:
+          project_id: astral-field-294621
+          workload_identity_provider: projects/643991131484/locations/global/workloadIdentityPools/github-actions/providers/warp-terraform
+          request_reason: Mirror warpdotdev/oz-agent-worker:${{ inputs.docker_tag }} to Artifact Registry
+
+      - name: Log in to Artifact Registry
+        if: inputs.docker_tag != ''
+        uses: docker/login-action@v4
+        with:
+          registry: us-east4-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp_auth.outputs.auth_token }}
 
       - name: Log in to DockerHub
         uses: docker/login-action@v4
@@ -142,8 +164,10 @@ jobs:
             {
               echo 'tags<<EOF'
               echo "warpdotdev/oz-agent-worker:${DOCKER_TAG}"
+              echo "us-east4-docker.pkg.dev/astral-field-294621/warp-public-images/oz-agent-worker:${DOCKER_TAG}"
               if [ "$PUBLISH_LATEST" = "true" ]; then
                 echo "warpdotdev/oz-agent-worker:latest"
+                echo "us-east4-docker.pkg.dev/astral-field-294621/warp-public-images/oz-agent-worker:latest"
               fi
               echo 'EOF'
               echo "primary=warpdotdev/oz-agent-worker:${DOCKER_TAG}"
@@ -157,7 +181,7 @@ jobs:
 
       - name: Build and push image
         id: push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/create_release.yml
+++ b/.github/workflows/create_release.yml
@@ -18,6 +18,9 @@ jobs:
 
   build:
     needs: generate-tag
+    permissions:
+      contents: read
+      id-token: write
     uses: ./.github/workflows/build_release.yml
     secrets: inherit
     with:


### PR DESCRIPTION
This modifies the worker release process to push images to both DockerHub and Google Artifact Registry.

Doing so lets users choose between either registry, depending on which performs better for them (e.g. depending on their own cloud provider or pull rate limits)