### PR TITLE
Sanitize Docker volume names for local-registry sidecar images

### DIFF
--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -514,8 +514,14 @@ func sanitizeVolumeName(imageName, digest string) string {
 		repoName = imageName
 	}
 
-	// Sanitize the repository name for use in volume name
-	baseName := strings.ReplaceAll(repoName, "/", "-")
+	// Local-registry image refs can contain ':' and '/', but Docker volume names
+	// only allow [a-zA-Z0-9_.-], so map every other character to '-'.
+	baseName := strings.Map(func(r rune) rune {
+		if r >= 'a' && r <= 'z' || r >= 'A' && r <= 'Z' || r >= '0' && r <= '9' || r == '_' || r == '.' || r == '-' {
+			return r
+		}
+		return '-'
+	}, repoName)
 
 	// digest format is typically "sha256:abc123..."
 	parts := strings.Split(digest, ":")


### PR DESCRIPTION
## What

Sanitize Docker volume names derived from sidecar image references by mapping any character outside `[a-zA-Z0-9_.-]` to `-`.

## Why

I hit this while testing an oz-local docker worker run that used a local-registry sidecar image like `localhost:5001/warp-agent:latest-local`. Local registries commonly include both a host/port prefix and a repository path (`host:port/repo:tag`), so the repository portion used for the sidecar filesystem volume can contain `:` and `/`.

The previous volume-name generation only replaced `/`. For `localhost:5001/warp-agent:latest-local`, Docker could still receive a local volume name with the `localhost:5001` colon in it, and fail volume creation with `includes invalid characters for a local volume name`.

This is needed for local-registry sidecar images because Docker local volume names only allow `[a-zA-Z0-9_.-]`, while image references allow additional separators. Sanitizing all unsupported characters keeps the sidecar image cache volume deterministic while avoiding Docker volume-name validation failures.

## Validation

- `go build ./internal/worker/`
- `go build ./...`

Oz run: https://oz.staging.warp.dev/runs/019f19d7-f055-754d-9953-19b24274f2ef

Co-Authored-By: Oz <oz-agent@warp.dev>
