### PR TITLE
k8s: detect OOM/preemption as structured failure reasons (REMOTE-2111)

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -120,6 +120,7 @@ const (
 	TaskFailureReasonInvalidImage    = "invalid_image"
 	TaskFailureReasonActiveDeadline  = "active_deadline"
 	TaskFailureReasonCleanup         = "cleanup"
+	TaskFailureReasonPodPreempted    = "pod_preempted"
 )
 
 var (
@@ -158,6 +159,7 @@ var (
 		TaskFailureReasonInvalidImage,
 		TaskFailureReasonActiveDeadline,
 		TaskFailureReasonCleanup,
+		TaskFailureReasonPodPreempted,
 	}
 )
 

--- a/internal/types/messages.go
+++ b/internal/types/messages.go
@@ -82,6 +82,10 @@ type TaskFailedMessage struct {
 	TaskID    string     `json:"task_id"`
 	Message   string     `json:"message"`
 	TaskState *TaskState `json:"task_state,omitempty"`
+	// FailureReason is the structured, machine-readable reason for the failure
+	// (e.g. "container_oom", "pod_preempted"). Used by the server for observability
+	// and timeline display without needing to parse the human-readable Message.
+	FailureReason string `json:"failure_reason,omitempty"`
 }
 
 // TaskRejectedMessage is sent from worker to server when the worker cannot accept the task

--- a/internal/worker/errors.go
+++ b/internal/worker/errors.go
@@ -44,14 +44,22 @@ func taskFailureLabels(err error) (phase, reason string) {
 }
 
 // userFacingTaskError returns a user-friendly error message for a task execution
-// failure. Well-known infrastructure errors (context cancellation, deadline exceeded)
-// are translated into clear, actionable messages instead of exposing raw Go error strings.
+// failure. Well-known infrastructure errors (context cancellation, deadline exceeded,
+// OOM, preemption) are translated into clear, actionable messages instead of exposing
+// raw Go error strings.
 func userFacingTaskError(err error) string {
 	switch {
 	case errors.Is(err, context.Canceled):
 		return "The task was interrupted due to an infrastructure issue (context canceled). This is typically transient — please try again."
 	case errors.Is(err, context.DeadlineExceeded):
 		return "The task exceeded its maximum allowed execution time and was terminated. Consider breaking the task into smaller steps or increasing the timeout."
+	}
+	_, reason := taskFailureLabels(err)
+	switch reason {
+	case "container_oom":
+		return "The task container was terminated because it ran out of memory (OOM killed). Consider increasing the runner memory limit or reducing the task's memory usage."
+	case "pod_preempted":
+		return "The task pod was preempted by the Kubernetes scheduler (evicted to make room for higher-priority workloads). The run was not checkpointed — please retry. Consider using higher-priority pods or nodes with sufficient capacity."
 	default:
 		return fmt.Sprintf("Failed to execute task: %v", err)
 	}

--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -942,17 +942,40 @@ func (b *KubernetesBackend) inspectPodFailure(ctx context.Context, pod *corev1.P
 			if event.Reason == "FailedMount" || strings.Contains(event.Message, "MountVolume.SetUp failed") {
 				return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonVolumeMount, b.podEventFailureError(pod, "failed to mount a volume", event))
 			}
+			if event.Reason == "Preempting" {
+				return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonPodPreempted, b.podEventFailureError(pod, "was preempted by the Kubernetes scheduler", event))
+			}
 		}
 	}
 	if pod.Status.Phase == corev1.PodFailed {
 		reason := metrics.TaskFailureReasonJobFailed
-		if strings.Contains(strings.ToLower(pod.Status.Reason+" "+pod.Status.Message), "deadline") {
+		podDetail := strings.ToLower(pod.Status.Reason + " " + pod.Status.Message)
+		switch {
+		case isPreemptedPod(pod):
+			reason = metrics.TaskFailureReasonPodPreempted
+		case strings.Contains(podDetail, "deadline"):
 			reason = metrics.TaskFailureReasonActiveDeadline
 		}
 		return newBackendFailure(metrics.TaskFailurePhaseBackend, reason, b.podFailureError(pod))
 	}
 
 	return nil
+}
+
+// isPreemptedPod returns true when a pod was preempted (evicted by the
+// scheduler to make room for higher-priority workloads). Kubernetes sets
+// Pod.Status.Reason to "Evicted" for all eviction causes, but preemption
+// events use reason "Preempting" and the eviction message typically contains
+// the word "preempt". We match both signals so detection works across
+// different Kubernetes versions and admission plugins.
+func isPreemptedPod(pod *corev1.Pod) bool {
+	if pod.Status.Reason == "Evicted" {
+		msg := strings.ToLower(pod.Status.Message)
+		if strings.Contains(msg, "preempt") {
+			return true
+		}
+	}
+	return false
 }
 
 func (b *KubernetesBackend) collectPodLogs(ctx context.Context, pods []corev1.Pod) string {

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -613,7 +613,7 @@ func (w *Worker) executeTask(ctx context.Context, taskCancel context.CancelFunc,
 		span.RecordError(err)
 		span.SetStatus(codes.Error, reason)
 		log.Errorf(ctx, "Task execution failed: taskID=%s, error=%v", taskID, err)
-		if statusErr := w.sendTaskFailed(taskID, userFacingTaskError(err)); statusErr != nil {
+		if statusErr := w.sendTaskFailed(taskID, userFacingTaskError(err), reason); statusErr != nil {
 			log.Errorf(ctx, "Failed to send task failed message: %v", statusErr)
 		}
 		return
@@ -735,10 +735,11 @@ func (w *Worker) sendTaskCompleted(taskID, message string) error {
 	return w.sendMessage(msgBytes)
 }
 
-func (w *Worker) sendTaskFailed(taskID, message string) error {
+func (w *Worker) sendTaskFailed(taskID, message, failureReason string) error {
 	failedMsg := types.TaskFailedMessage{
-		TaskID:  taskID,
-		Message: message,
+		TaskID:        taskID,
+		Message:       message,
+		FailureReason: failureReason,
 	}
 
 	data, err := json.Marshal(failedMsg)


### PR DESCRIPTION
## Context

Addresses [REMOTE-2111](https://linear.app/warpdotdev/issue/REMOTE-2111): enterprise customer (IMC) asked how k8s worker pods handle OOM kills and pod preemptions.

**Current behavior:** when a k8s worker pod is OOM-killed or preempted, the cloud agent run fails with no state preservation, no snapshotting, and no resumption. This PR does not change that (checkpointing is a larger investment), but improves observability so users and operators know _why_ a run failed.

## Changes

### Preemption detection
- `inspectPodFailure` now checks for pod preemption via two signals:
  1. Kubernetes event with `Reason == "Preempting"` (emitted by the scheduler before eviction)
  2. `Pod.Status.Phase == Failed` with `Status.Reason == "Evicted"` and a message containing "preempt" (covers different k8s versions and eviction plugins)
- Classified as new `pod_preempted` failure reason (previously fell through as generic `job_failed` or `container_exit`)

### OOM classification already existed but is now surfaced better
- `classifyTerminatedReason("OOMKilled")` → `container_oom` was already tracked in metrics; now also carried through in user-facing messages and the wire protocol

### Structured `FailureReason` in `TaskFailedMessage`
- New optional `FailureReason string` field (JSON: `failure_reason`) so the server can identify OOM/preemption without parsing the human-readable message string
- Companion warp-server PR accepts this field and logs it

### Better user-facing error messages
- `container_oom`: "The task container was terminated because it ran out of memory (OOM killed). Consider increasing the runner memory limit or reducing the task's memory usage."
- `pod_preempted`: "The task pod was preempted by the Kubernetes scheduler (evicted to make room for higher-priority workloads). The run was not checkpointed — please retry. Consider using higher-priority pods or nodes with sufficient capacity."

## Testing

- `go test ./internal/worker/...` passes
- `go build ./...` passes

_Conversation: https://staging.warp.dev/conversation/c5421a3c-e5ac-459e-bf33-9c988a87de8a_
_Run: https://oz.staging.warp.dev/runs/019f4843-caaf-719a-861a-dd6cd9042bba_

_This PR was generated with [Oz](https://warp.dev/oz)._
