### PR TITLE
feat: add Grafana dashboard template and Prometheus alerting rules for self-hosted workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,6 +367,16 @@ shows up as a distinct series.
 - `oz_worker_info{version,backend,worker_id}` (gauge, value `1`): build and
   runtime metadata, useful for joining other series by labels.
 
+### Grafana dashboard
+
+A ready-to-import Grafana dashboard and Prometheus alerting rules are available in the [`grafana/`](grafana/) directory:
+
+- [`grafana/oz-agent-worker-overview.json`](grafana/oz-agent-worker-overview.json) — importable Grafana 10+ dashboard covering all `oz_worker_*` metrics
+- [`grafana/alerts.yaml`](grafana/alerts.yaml) — Prometheus alerting rules for connectivity, saturation, and task failures
+- [`grafana/README.md`](grafana/README.md) — import instructions for Grafana UI, API, and Prometheus Operator
+
+Quick import via Grafana UI: **Dashboards → Import → Upload JSON file** → select `grafana/oz-agent-worker-overview.json` → choose your Prometheus datasource.
+
 ### Sample dashboards / alerts
 
 Direct mappings for the questions enterprise operators most commonly ask:

--- a/grafana/README.md
+++ b/grafana/README.md
@@ -1,0 +1,127 @@
+# Oz Agent Worker — Grafana Resources
+
+This directory contains a ready-to-import Grafana dashboard and Prometheus alerting rules for self-hosted Oz worker deployments.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `oz-agent-worker-overview.json` | Importable Grafana dashboard (Grafana 10+) |
+| `alerts.yaml` | Prometheus alerting rules (vanilla Prometheus or Prometheus Operator) |
+
+## Prerequisites
+
+Before importing, enable Prometheus metrics on the worker:
+
+```bash
+export OTEL_METRICS_EXPORTER=prometheus
+export OTEL_EXPORTER_PROMETHEUS_HOST=0.0.0.0
+export OTEL_EXPORTER_PROMETHEUS_PORT=9464
+oz-agent-worker --api-key "$WARP_API_KEY" --worker-id my-worker
+```
+
+Or in the Helm chart:
+
+```bash
+helm install oz-agent-worker ./charts/oz-agent-worker \
+  --namespace warp-oz \
+  --set worker.workerId=my-worker \
+  --set image.tag=VERSION \
+  --set metrics.enabled=true
+```
+
+Verify the endpoint is serving metrics before importing the dashboard:
+
+```bash
+curl -s localhost:9464/metrics | grep oz_worker_
+```
+
+## Importing the dashboard
+
+### Option 1 — Grafana UI
+
+1. In Grafana, go to **Dashboards** → **Import**.
+2. Click **Upload JSON file** and select `oz-agent-worker-overview.json`.
+3. When prompted, select your Prometheus datasource.
+4. Click **Import**.
+
+### Option 2 — Grafana API
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $GRAFANA_API_KEY" \
+  --data-binary @oz-agent-worker-overview.json \
+  http://your-grafana/api/dashboards/import
+```
+
+### Option 3 — Direct URL
+
+If the worker binary is available on GitHub, you can import from the raw URL directly in the Grafana UI (**Import** → **Import via grafana.com or URL** → paste the raw GitHub URL):
+
+```
+https://raw.githubusercontent.com/warpdotdev/oz-agent-worker/main/grafana/oz-agent-worker-overview.json
+```
+
+## Dashboard layout
+
+The dashboard has five sections:
+
+| Row | Panels |
+|-----|--------|
+| **Worker Health** | Connected workers, active workers, tasks active, fleet saturation |
+| **Task Throughput** | Task completion rate by result, 5m success rate, 5m rejection rate |
+| **Task Duration** | p50 / p95 / p99 latency |
+| **Failure Analysis** | Failure rate by reason, failure rate by phase |
+| **Connection Health** | WebSocket reconnect rate, worker fleet info table |
+
+### Instance filter
+
+The **Instance** variable at the top of the dashboard lets you filter to a specific worker pod or scrape target. Set it to **All** (the default) to see fleet-wide aggregations.
+
+## Using the alert rules
+
+### Vanilla Prometheus
+
+1. Copy `alerts.yaml` to your Prometheus rules directory (e.g., `/etc/prometheus/rules/`).
+2. Reference it in `prometheus.yml`:
+
+   ```yaml
+   rule_files:
+     - /etc/prometheus/rules/alerts.yaml
+   ```
+
+3. Reload Prometheus: `curl -X POST http://localhost:9090/-/reload`
+
+### Prometheus Operator (Kubernetes)
+
+Wrap the `groups` block in a `PrometheusRule` custom resource:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: oz-agent-worker
+  namespace: warp-oz
+  labels:
+    # Match your Prometheus Operator's ruleSelector labels
+    prometheus: kube-prometheus
+    role: alert-rules
+spec:
+  groups:
+    # Paste the contents of alerts.yaml `groups:` block here
+```
+
+### Tuning thresholds
+
+All alert thresholds are conservative starting points. Tune them to match your fleet size, task volume, and SLOs:
+
+- `OzWorkerFleetSaturated`: raise the 0.9 threshold for fleets that run near capacity by design.
+- `OzWorkerHighFailureRate`: lower the 0.1 threshold (10%) to catch smaller failure spikes.
+- `OzWorkerReconnectStorm`: adjust the 0.1/s threshold based on your expected reconnect baseline.
+
+## Related documentation
+
+- [Self-hosted worker monitoring](https://docs.warp.dev/platform/self-hosting/monitoring/) — full metrics reference and PromQL examples
+- [Self-hosted worker overview](https://docs.warp.dev/platform/self-hosting/) — architecture and deployment patterns
+- [Helm chart configuration](https://docs.warp.dev/platform/self-hosting/managed-kubernetes/) — enabling metrics via Helm values

--- a/grafana/alerts.yaml
+++ b/grafana/alerts.yaml
@@ -1,0 +1,153 @@
+# Prometheus alerting rules for self-hosted Oz agent workers.
+#
+# Usage:
+#   - Vanilla Prometheus: place this file in your Prometheus rules directory
+#     and reference it from prometheus.yml under `rule_files:`.
+#   - Prometheus Operator: wrap the `groups` block in a PrometheusRule CRD
+#     (apiVersion: monitoring.coreos.com/v1, kind: PrometheusRule).
+#
+# All thresholds are conservative starting points. Tune them for your fleet
+# size, task volume, and SLOs before enabling in production.
+
+groups:
+  - name: oz_agent_worker
+    interval: 60s
+    rules:
+
+      # ── Connectivity ──────────────────────────────────────────────────────
+
+      - alert: OzWorkerDisconnected
+        expr: |
+          oz_worker_connected == 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oz worker {{ $labels.instance }} has lost its connection to Oz"
+          description: >
+            Worker {{ $labels.instance }} has reported oz_worker_connected=0 for
+            more than 2 minutes. The worker is no longer accepting tasks.
+            Check network egress to oz.warp.dev and review worker logs.
+
+      - alert: OzWorkerReconnectStorm
+        expr: |
+          sum by (instance) (rate(oz_worker_websocket_reconnects_total[5m])) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oz worker {{ $labels.instance }} is reconnecting frequently"
+          description: >
+            Worker {{ $labels.instance }} is reconnecting to warp-server at a rate
+            of {{ $value | humanize }}/s (threshold: 0.1/s). This may indicate
+            network instability, TLS issues, or server-side disruptions.
+
+      # ── Capacity ──────────────────────────────────────────────────────────
+
+      - alert: OzWorkerFleetSaturated
+        expr: |
+          (
+            sum(oz_worker_tasks_active) /
+            sum(oz_worker_tasks_max_concurrent != 0)
+          ) > 0.9
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oz worker fleet is running at high capacity"
+          description: >
+            The fleet is using {{ $value | humanizePercentage }} of configured
+            concurrency capacity (threshold: 90%). Tasks may start experiencing
+            rejections. Consider increasing max_concurrent_tasks or deploying
+            additional worker instances.
+          runbook: |
+            1. Check oz_worker_tasks_rejected_total for recent rejections.
+            2. Review oz_worker_task_duration_seconds to see if tasks are running longer than expected.
+            3. Increase max_concurrent_tasks in worker config, or deploy more worker pods.
+
+      - alert: OzWorkerTasksRejected
+        expr: |
+          sum(rate(oz_worker_tasks_rejected_total[5m])) > 0
+        for: 1m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oz workers are rejecting tasks"
+          description: >
+            Workers are rejecting tasks at {{ $value | humanize }}/s. Rejections
+            occur when a worker is at its concurrency limit (max_concurrent_tasks).
+            Increase capacity or the concurrency limit to stop dropping tasks.
+
+      # ── Task failures ─────────────────────────────────────────────────────
+
+      - alert: OzWorkerHighFailureRate
+        expr: |
+          (
+            sum(rate(oz_worker_tasks_completed_total{result="failed"}[5m])) /
+            sum(rate(oz_worker_tasks_completed_total[5m]))
+          ) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oz worker task failure rate is elevated"
+          description: >
+            {{ $value | humanizePercentage }} of completed tasks have failed over
+            the last 5 minutes (threshold: 10%). Check
+            oz_worker_task_failures_total{phase,reason} for the root cause.
+
+      - alert: OzWorkerImagePullFailures
+        expr: |
+          sum(rate(oz_worker_task_failures_total{reason="image_pull"}[5m])) > 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oz worker is failing to pull task images"
+          description: >
+            Workers are failing to pull container images at
+            {{ $value | humanize }}/s. Check image registry access, pull secrets,
+            and image availability. For Kubernetes, confirm imagePullSecrets are
+            configured and the registry is reachable from the cluster.
+
+      - alert: OzWorkerContainerOOM
+        expr: |
+          sum(rate(oz_worker_task_failures_total{reason="container_oom"}[5m])) > 0
+        for: 2m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oz worker task containers are being OOM-killed"
+          description: >
+            Task containers are being killed due to memory limits at
+            {{ $value | humanize }}/s. Review the memory limits set in
+            pod_template or the instance shape for the runs that are failing,
+            and increase them if tasks require more memory.
+
+      - alert: OzWorkerUnschedulablePods
+        expr: |
+          sum(rate(oz_worker_task_failures_total{reason="unschedulable"}[5m])) > 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Oz worker task pods are failing to schedule"
+          description: >
+            Kubernetes task pods are becoming unschedulable at
+            {{ $value | humanize }}/s. Check node capacity, taints, tolerations,
+            resource requests in pod_template, and cluster autoscaler status.
+
+      # ── No workers connected ──────────────────────────────────────────────
+
+      - alert: OzWorkerFleetEmpty
+        expr: |
+          sum(oz_worker_connected) == 0
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: "No Oz workers are connected"
+          description: >
+            No workers have an active connection to Oz. Cloud agent tasks cannot
+            be dispatched to self-hosted infrastructure. Check worker pod
+            readiness, API key validity, and network egress to oz.warp.dev.

--- a/grafana/oz-agent-worker-overview.json
+++ b/grafana/oz-agent-worker-overview.json
@@ -1,0 +1,1304 @@
+{
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS",
+      "label": "Prometheus",
+      "description": "Prometheus datasource scraping oz-agent-worker /metrics endpoints",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__elements": {},
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "10.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "gauge",
+      "name": "Gauge",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "stat",
+      "name": "Stat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "timeseries",
+      "name": "Time series",
+      "version": ""
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Operational dashboard for self-hosted Oz agent workers (oz-agent-worker). Covers worker health, task throughput, latency, failure analysis, and WebSocket connectivity. Import and select your Prometheus datasource. Requires OTEL_METRICS_EXPORTER=prometheus (or OTLP → Prometheus) on each worker.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [
+    {
+      "asDropdown": false,
+      "icon": "external link",
+      "includeVars": false,
+      "keepTime": false,
+      "tags": [],
+      "targetBlank": true,
+      "title": "Self-hosted worker docs",
+      "tooltip": "Warp self-hosted worker monitoring documentation",
+      "type": "link",
+      "url": "https://docs.warp.dev/platform/self-hosting/monitoring/"
+    }
+  ],
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "title": "Worker Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Number of workers with an active WebSocket connection to Oz. Value drops to 0 when a worker loses its connection.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(oz_worker_connected{instance=~\"$instance\"})",
+          "instant": true,
+          "legendFormat": "Connected",
+          "refId": "A"
+        }
+      ],
+      "title": "Connected Workers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Workers currently executing at least one task.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 6,
+        "y": 1
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "count(oz_worker_tasks_active{instance=~\"$instance\"} > 0) or vector(0)",
+          "instant": true,
+          "legendFormat": "Active",
+          "refId": "A"
+        }
+      ],
+      "title": "Active Workers",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Total tasks currently executing across all selected workers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "blue",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 12,
+        "y": 1
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(oz_worker_tasks_active{instance=~\"$instance\"})",
+          "instant": true,
+          "legendFormat": "Active tasks",
+          "refId": "A"
+        }
+      ],
+      "title": "Tasks Active",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Ratio of active tasks to total configured concurrency capacity. Only includes workers with a non-zero max_concurrent limit. Workers configured as unlimited (max_concurrent=0) are excluded from the denominator.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.7
+              },
+              {
+                "color": "red",
+                "value": 0.9
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 1
+      },
+      "id": 5,
+      "options": {
+        "minVizHeight": 75,
+        "minVizWidth": 75,
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(oz_worker_tasks_active{instance=~\"$instance\"}) / sum(oz_worker_tasks_max_concurrent{instance=~\"$instance\"} != 0)",
+          "instant": true,
+          "legendFormat": "Saturation",
+          "refId": "A"
+        }
+      ],
+      "title": "Fleet Saturation",
+      "type": "gauge"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 6,
+      "title": "Task Throughput",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Per-second rate of task completions by result, and rejected tasks. Rejected tasks occur when a worker is at its concurrency limit.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "tasks/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "failed"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "red",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "succeeded"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "green",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "cancelled"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "rejected"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "purple",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 16,
+        "x": 0,
+        "y": 6
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(oz_worker_tasks_completed_total{result=\"succeeded\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "succeeded",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(oz_worker_tasks_completed_total{result=\"failed\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "failed",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(oz_worker_tasks_completed_total{result=\"cancelled\",instance=~\"$instance\"}[5m]))",
+          "legendFormat": "cancelled",
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(oz_worker_tasks_rejected_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "rejected",
+          "refId": "D"
+        }
+      ],
+      "title": "Task Completion Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Fraction of completed tasks that succeeded over the last 5 minutes. Returns no data if no tasks have completed yet.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.9
+              },
+              {
+                "color": "green",
+                "value": 0.98
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 6
+      },
+      "id": 8,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(oz_worker_tasks_completed_total{result=\"succeeded\",instance=~\"$instance\"}[5m])) / sum(rate(oz_worker_tasks_completed_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Success rate",
+          "refId": "A"
+        }
+      ],
+      "title": "5m Task Success Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Per-second rate at which workers are rejecting tasks. A non-zero rate typically means workers are at their concurrency limit. Consider increasing max_concurrent_tasks or adding more workers.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.01
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "id": 9,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(oz_worker_tasks_rejected_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "Rejection rate",
+          "refId": "A"
+        }
+      ],
+      "title": "5m Task Rejection Rate",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 14
+      },
+      "id": 10,
+      "title": "Task Duration",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Wall-clock duration of task execution on the worker, broken down by p50, p95, and p99. The histogram is not primed at startup, so this panel shows no data until at least one task completes.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "duration",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max",
+            "p95"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.5, sum by (le) (rate(oz_worker_task_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "p50",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(oz_worker_task_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "p95",
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "histogram_quantile(0.99, sum by (le) (rate(oz_worker_task_duration_seconds_bucket{instance=~\"$instance\"}[5m])))",
+          "legendFormat": "p99",
+          "refId": "C"
+        }
+      ],
+      "title": "Task Duration (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 23
+      },
+      "id": 12,
+      "title": "Failure Analysis",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Per-second failure rate broken down by reason. Common reasons include image_pull, unschedulable, container_oom, agent_invocation. A spike in a single reason usually indicates a infrastructure-specific problem.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "failures/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (reason) (rate(oz_worker_task_failures_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Task Failure Rate by Reason",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Per-second failure rate by execution phase. 'backend' phase covers container/pod lifecycle failures. 'assignment' phase covers failures before a task starts. 'cleanup' phase covers post-task teardown failures.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "failures/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 14,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (phase) (rate(oz_worker_task_failures_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{phase}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Task Failure Rate by Phase",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 32
+      },
+      "id": 15,
+      "title": "Connection Health",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Rate of WebSocket reconnect attempts to warp-server, broken down by reason. 'dial_failed' means the worker could not establish a new connection; 'remote_close' means the server closed the connection. A sustained rate above 0.1/s may indicate network instability or server-side issues.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "reconnects/s",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.1
+              }
+            ]
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 14,
+        "x": 0,
+        "y": 33
+      },
+      "id": 16,
+      "options": {
+        "legend": {
+          "calcs": [
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum by (reason) (rate(oz_worker_websocket_reconnects_total{instance=~\"$instance\"}[5m]))",
+          "legendFormat": "{{reason}}",
+          "refId": "A"
+        }
+      ],
+      "title": "WebSocket Reconnects",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "description": "Current worker fleet: version, backend, and worker ID for each running worker process. Shows one row per worker. Values come from the oz_worker_info gauge (constant 1 with build metadata as labels).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Time"
+            },
+            "properties": [
+              {
+                "id": "custom.hidden",
+                "value": true
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 10,
+        "x": 14,
+        "y": 33
+      },
+      "id": 17,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": [
+            "sum"
+          ],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "worker_id"
+          }
+        ]
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "oz_worker_info{instance=~\"$instance\"}",
+          "format": "table",
+          "instant": true,
+          "legendFormat": "__auto",
+          "refId": "A"
+        }
+      ],
+      "title": "Worker Fleet Info",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value": true,
+              "__name__": true,
+              "job": true
+            },
+            "indexByName": {
+              "backend": 2,
+              "instance": 3,
+              "version": 1,
+              "worker_id": 0
+            },
+            "renameByName": {
+              "backend": "Backend",
+              "instance": "Instance",
+              "version": "Version",
+              "worker_id": "Worker ID"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 39,
+  "tags": [
+    "oz",
+    "warp",
+    "self-hosted",
+    "agents"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {},
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": true,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "type": "prometheus",
+          "uid": "${DS_PROMETHEUS}"
+        },
+        "definition": "label_values(oz_worker_connected, instance)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Instance",
+        "multi": true,
+        "name": "instance",
+        "options": [],
+        "query": {
+          "query": "label_values(oz_worker_connected, instance)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "type": "query"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Oz Agent Worker",
+  "uid": "oz-agent-worker-v1",
+  "version": 1
+}


### PR DESCRIPTION
## Summary

Adds a ready-to-import Grafana dashboard and Prometheus alerting rules for enterprise customers running self-hosted Oz workers.

Addresses feedback from enterprise customer IMC ([REMOTE-2110](https://linear.app/warpdotdev/issue/REMOTE-2110)) who asked for Grafana dashboard templates they can import for their self-hosted Oz worker deployment.

## Changes

### New: `grafana/` directory

- **`grafana/oz-agent-worker-overview.json`** — Importable Grafana 10+ dashboard with 5 sections:
  - **Worker Health**: Connected workers, active workers, tasks active, fleet saturation gauge (green/yellow/red)
  - **Task Throughput**: Task completion rate by result (succeeded/failed/cancelled/rejected), 5m success rate, 5m rejection rate
  - **Task Duration**: p50 / p95 / p99 latency over sliding 5m window
  - **Failure Analysis**: Failure rate by reason (e.g., `image_pull`, `container_oom`, `unschedulable`) and by phase
  - **Connection Health**: WebSocket reconnect rate by reason, worker fleet info table

  Uses `__inputs` for datasource substitution at import time. Includes an Instance variable for per-worker drill-down.

- **`grafana/alerts.yaml`** — Prometheus alerting rules covering: `OzWorkerFleetEmpty` (critical), `OzWorkerDisconnected`, `OzWorkerReconnectStorm`, `OzWorkerFleetSaturated`, `OzWorkerTasksRejected`, `OzWorkerHighFailureRate`, `OzWorkerImagePullFailures`, `OzWorkerContainerOOM`, `OzWorkerUnschedulablePods`. Compatible with vanilla Prometheus and Prometheus Operator.

- **`grafana/README.md`** — Import instructions for Grafana UI, Grafana API, and direct URL. Covers alert rule deployment (vanilla + Prometheus Operator) and threshold tuning guidance.

### Updated: `README.md`

Added a "Grafana dashboard" subsection under the Monitoring section pointing to the `grafana/` directory.

## Testing

- JSON validated with `python3 -m json.tool` (valid)
- Dashboard uses standard Grafana 10 schema (schemaVersion: 39)
- PromQL expressions match the metric names in `internal/metrics/metrics.go`
- Alert thresholds are conservative starting points with tuning guidance in `grafana/README.md`

_Conversation: https://staging.warp.dev/conversation/3861b9b2-ce49-46f7-baff-bfb3e2173b0b_
_Run: https://oz.staging.warp.dev/runs/019f4843-a02c-7ca4-aa34-0d867981dfbc_

_This PR was generated with [Oz](https://warp.dev/oz)._
