### PR TITLE
k8s: make preflight Job resource requests/limits configurable via YAML config and Helm chart

### DIFF
--- a/charts/oz-agent-worker/templates/configmap.yaml
+++ b/charts/oz-agent-worker/templates/configmap.yaml
@@ -57,3 +57,7 @@ data:
         pod_template:
 {{ toYaml .Values.kubernetesBackend.podTemplate | indent 10 }}
         {{- end }}
+        {{- if .Values.kubernetesBackend.preflightResources }}
+        preflight_resources:
+{{ toYaml .Values.kubernetesBackend.preflightResources | indent 10 }}
+        {{- end }}

--- a/charts/oz-agent-worker/values.yaml
+++ b/charts/oz-agent-worker/values.yaml
@@ -97,9 +97,7 @@ kubernetesBackend:
   # matching resources set on the "task" container here (other entries are preserved).
   podTemplate: {}
   # Optional: cpu/memory requests and limits applied to the startup preflight
-  # Job containers. When omitted the worker uses built-in defaults (10m CPU /
-  # 16Mi memory requests; 100m CPU / 64Mi memory limits) that satisfy admission
-  # policies requiring all containers to declare resource constraints.
+  # Job containers. When omitted the worker applies default resource constraints.
   # Example:
   #   preflightResources:
   #     requests:

--- a/charts/oz-agent-worker/values.yaml
+++ b/charts/oz-agent-worker/values.yaml
@@ -96,6 +96,19 @@ kubernetesBackend:
   # container's CPU/memory requests and limits from that shape per run, overriding any
   # matching resources set on the "task" container here (other entries are preserved).
   podTemplate: {}
+  # Optional: cpu/memory requests and limits applied to the startup preflight
+  # Job containers. When omitted the worker uses built-in defaults (10m CPU /
+  # 16Mi memory requests; 100m CPU / 64Mi memory limits) that satisfy admission
+  # policies requiring all containers to declare resource constraints.
+  # Example:
+  #   preflightResources:
+  #     requests:
+  #       cpu: 10m
+  #       memory: 16Mi
+  #     limits:
+  #       cpu: 100m
+  #       memory: 64Mi
+  preflightResources: {}
 
 # Metrics export uses the OpenTelemetry autoexport package, so the operator
 # selects the exporter via standard OpenTelemetry environment variables. When

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,12 @@ type KubernetesConfig struct {
 	// serviceAccountName, imagePullSecrets, node selectors, tolerations,
 	// resources, and env must be configured here.
 	PodTemplate *RawYAMLNode `yaml:"pod_template"`
+	// PreflightResources holds optional cpu/memory requests and limits for the
+	// startup preflight Job containers. When unset, the worker uses small
+	// built-in defaults (10m CPU / 16Mi memory requests; 100m CPU / 64Mi memory
+	// limits) that satisfy admission policies requiring all containers to declare
+	// resource constraints.
+	PreflightResources *RawYAMLNode `yaml:"preflight_resources"`
 }
 
 // RawYAMLNode captures a raw YAML sub-tree without applying KnownFields validation

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -83,10 +83,7 @@ type KubernetesConfig struct {
 	// resources, and env must be configured here.
 	PodTemplate *RawYAMLNode `yaml:"pod_template"`
 	// PreflightResources holds optional cpu/memory requests and limits for the
-	// startup preflight Job containers. When unset, the worker uses small
-	// built-in defaults (10m CPU / 16Mi memory requests; 100m CPU / 64Mi memory
-	// limits) that satisfy admission policies requiring all containers to declare
-	// resource constraints.
+	// startup preflight Job containers.
 	PreflightResources *RawYAMLNode `yaml:"preflight_resources"`
 }
 

--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -79,6 +79,10 @@ type KubernetesBackendConfig struct {
 	// PodTemplate, when non-nil, is the declarative PodSpec template for task
 	// Jobs. Worker-required fields are overlaid at execution time.
 	PodTemplate *corev1.PodSpec
+	// PreflightResources, when non-nil, overrides the default cpu/memory
+	// requests and limits applied to startup preflight Job containers.
+	// Defaults: requests 10m CPU / 16Mi memory; limits 100m CPU / 64Mi memory.
+	PreflightResources *corev1.ResourceRequirements
 }
 
 // KubernetesBackend executes tasks in Kubernetes Jobs.
@@ -669,7 +673,7 @@ func (b *KubernetesBackend) startupPreflightJob() *batchv1.Job {
 	pullPolicy := normalizePullPolicy(b.config.ImagePullPolicy)
 	podSpec := b.basePodSpec()
 	podSpec.RestartPolicy = corev1.RestartPolicyNever
-	preflightRes := preflightResourceRequirements()
+	preflightRes := b.preflightResourceRequirements()
 	if b.config.UseImageVolumes {
 		podSpec.InitContainers = nil
 		podSpec.Volumes = append(podSpec.Volumes, imageVolume(startupPreflightImageVolumeName, b.config.PreflightImage, pullPolicy))
@@ -1175,12 +1179,18 @@ func mergeKubernetesEnvVars(base, override []corev1.EnvVar) []corev1.EnvVar {
 	return result
 }
 
-// preflightResourceRequirements returns fixed, minimal cpu/memory requests and
-// limits for the startup preflight Job containers. The preflight runs once at
-// startup and does essentially no work (busybox true / test -d), so these
-// values are intentionally tiny. They satisfy admission policies that require
-// all containers to declare resource requests and limits.
-func preflightResourceRequirements() corev1.ResourceRequirements {
+// preflightResourceRequirements returns the cpu/memory requests and limits for
+// the startup preflight Job containers. When the backend config supplies
+// PreflightResources, those values are used. Otherwise the built-in defaults
+// are returned (10m CPU / 16Mi memory requests; 100m CPU / 64Mi memory
+// limits). The preflight runs once at startup and does essentially no work
+// (busybox true / test -d), so these defaults are intentionally tiny. They
+// satisfy admission policies that require all containers to declare resource
+// requests and limits.
+func (b *KubernetesBackend) preflightResourceRequirements() corev1.ResourceRequirements {
+	if b.config.PreflightResources != nil {
+		return *b.config.PreflightResources
+	}
 	return corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
 			corev1.ResourceCPU:    resource.MustParse("10m"),

--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -1182,11 +1182,7 @@ func mergeKubernetesEnvVars(base, override []corev1.EnvVar) []corev1.EnvVar {
 // preflightResourceRequirements returns the cpu/memory requests and limits for
 // the startup preflight Job containers. When the backend config supplies
 // PreflightResources, those values are used. Otherwise the built-in defaults
-// are returned (10m CPU / 16Mi memory requests; 100m CPU / 64Mi memory
-// limits). The preflight runs once at startup and does essentially no work
-// (busybox true / test -d), so these defaults are intentionally tiny. They
-// satisfy admission policies that require all containers to declare resource
-// requests and limits.
+// are returned.
 func (b *KubernetesBackend) preflightResourceRequirements() corev1.ResourceRequirements {
 	if b.config.PreflightResources != nil {
 		return *b.config.PreflightResources

--- a/main.go
+++ b/main.go
@@ -201,6 +201,7 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 			workspaceSizeLimit    *resource.Quantity
 			unschedulableTimeout  *time.Duration
 			podTemplate           *corev1.PodSpec
+			preflightResources    *corev1.ResourceRequirements
 		)
 
 		if fileConfig != nil && fileConfig.Backend.Kubernetes != nil {
@@ -244,6 +245,17 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 				}
 				podTemplate = &ps
 			}
+			if kc.PreflightResources != nil {
+				yamlBytes, err := yaml.Marshal(kc.PreflightResources.Node)
+				if err != nil {
+					return worker.Config{}, fmt.Errorf("failed to marshal backend.kubernetes.preflight_resources: %w", err)
+				}
+				var rr corev1.ResourceRequirements
+				if err := sigsk8syaml.Unmarshal(yamlBytes, &rr); err != nil {
+					return worker.Config{}, fmt.Errorf("invalid backend.kubernetes.preflight_resources: %w", err)
+				}
+				preflightResources = &rr
+			}
 		}
 
 		wc.Kubernetes = &worker.KubernetesBackendConfig{
@@ -267,6 +279,7 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 			UnschedulableTimeout:  unschedulableTimeout,
 			TaskEnv:               copyStringMap(cliEnv),
 			PodTemplate:           podTemplate,
+			PreflightResources:    preflightResources,
 		}
 	case "direct":
 		// Merge env: config file first, then CLI overlay.


### PR DESCRIPTION
PR #97 added preflight resource requests/limits to satisfy Kubernetes admission policies, but the values were hardcoded. This PR restores configurability so operators can override them via the YAML config file and Helm chart, while keeping the same hardcoded values as defaults.

## Changes

- `internal/config/config.go` — add `PreflightResources *RawYAMLNode` field to `KubernetesConfig`
- `main.go` — parse `PreflightResources` from config and pass to `KubernetesBackendConfig` (same pattern as `pod_template`)
- `internal/worker/kubernetes.go` — add `PreflightResources *corev1.ResourceRequirements` to `KubernetesBackendConfig`; convert `preflightResourceRequirements()` from a standalone function to a method that returns the configured value when set, or the built-in defaults otherwise
- `charts/oz-agent-worker/values.yaml` — add `kubernetesBackend.preflightResources` (empty by default, so hardcoded defaults are used)
- `charts/oz-agent-worker/templates/configmap.yaml` — render `preflight_resources` into the worker config YAML when set

## Usage

Helm:
```yaml
kubernetesBackend:
  preflightResources:
    requests:
      cpu: 10m
      memory: 16Mi
    limits:
      cpu: 100m
      memory: 64Mi
```

YAML config file:
```yaml
backend:
  kubernetes:
    preflight_resources:
      requests:
        cpu: 10m
        memory: 16Mi
      limits:
        cpu: 100m
        memory: 64Mi
```

Existing deployments that don't set `preflightResources` continue to use the same built-in defaults from PR #97.

_Conversation: https://staging.warp.dev/conversation/a7fe2e10-5043-48d7-9105-6242b29401de_
_Run: https://oz.staging.warp.dev/runs/019f48d0-40a6-7a23-ba69-964cd3e45acf_

_This PR was generated with [Oz](https://warp.dev/oz)._
