### PR TITLE
Update job and pod names so they contain run ID

### DIFF
--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -138,7 +138,7 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 	}
 
 	executionID := taskExecutionID(params)
-	jobName := sanitizeKubernetesJobName(executionID)
+	jobName := kubernetesTaskJobName(params.TaskID, executionID)
 	jobLabels := b.baseLabels(params.TaskID, executionID)
 	jobAnnotations := copyStringMap(b.config.ExtraAnnotations)
 	pullPolicy := normalizePullPolicy(b.config.ImagePullPolicy)
@@ -1047,23 +1047,50 @@ func copyStringMap(values map[string]string) map[string]string {
 	return result
 }
 
-func sanitizeKubernetesJobName(taskID string) string {
-	suffix := sanitizeKubernetesNameFragment(taskID)
-	if suffix == "" {
-		suffix = "task"
+// taskJobExecIDSuffixLen is how many trailing characters of the execution ID are
+// appended after the full run ID in a task Job name. It disambiguates re-executions
+// (follow-up/handoff) of the same run while keeping the Job name within Kubernetes'
+// 63-character limit for the job-name label the controller stamps on Pods.
+const taskJobExecIDSuffixLen = 8
+
+// kubernetesTaskJobName builds the task Job name as oz-task-<run>-exec-<exec-suffix>.
+// The Job controller appends a random suffix when it creates the task Pod, so the Pod
+// name becomes oz-task-<run>-exec-<exec-suffix>-<random>. The full run ID is embedded so
+// Jobs and Pods stay greppable by run, while a short execution-ID suffix keeps the name
+// unique across re-executions of the same run. The run fragment is truncated only as a
+// defensive fallback so the name stays within the 63-character limit; a standard
+// 36-character UUID run ID always fits without truncation.
+func kubernetesTaskJobName(runID, executionID string) string {
+	execFragment := lastKubernetesIDFragment(executionID, taskJobExecIDSuffixLen)
+	if execFragment == "" {
+		execFragment = "exec"
 	}
 
-	hash := kubernetesLabelHash(taskID)
-	maxSuffixLength := 63 - len("oz-task--") - len(hash)
-	if len(suffix) > maxSuffixLength {
-		suffix = suffix[:maxSuffixLength]
-		suffix = strings.Trim(suffix, "-")
+	const prefix, sep = "oz-task-", "-exec-"
+	maxRunLen := 63 - len(prefix) - len(sep) - len(execFragment)
+	if maxRunLen < 0 {
+		maxRunLen = 0
 	}
-	if suffix == "" {
-		suffix = "task"
+	runFragment := sanitizeKubernetesNameFragment(runID)
+	if len(runFragment) > maxRunLen {
+		runFragment = strings.Trim(runFragment[:maxRunLen], "-")
+	}
+	if runFragment == "" {
+		runFragment = "run"
 	}
 
-	return fmt.Sprintf("oz-task-%s-%s", suffix, hash)
+	return prefix + runFragment + sep + execFragment
+}
+
+// lastKubernetesIDFragment returns a DNS-label-safe fragment built from the last n
+// characters of the sanitized id. It returns an empty string when id has no usable
+// characters, so callers can substitute a fallback.
+func lastKubernetesIDFragment(id string, n int) string {
+	sanitized := sanitizeKubernetesNameFragment(id)
+	if len(sanitized) > n {
+		sanitized = strings.Trim(sanitized[len(sanitized)-n:], "-")
+	}
+	return sanitized
 }
 
 func sanitizeKubernetesLabelValue(value string) string {

--- a/internal/worker/kubernetes_test.go
+++ b/internal/worker/kubernetes_test.go
@@ -21,21 +21,49 @@ func durationPtr(value time.Duration) *time.Duration {
 	return &value
 }
 
-func TestSanitizeKubernetesJobNameUsesHashSuffix(t *testing.T) {
-	first := sanitizeKubernetesJobName("Task A")
-	second := sanitizeKubernetesJobName("Task-A")
+func TestKubernetesTaskJobNameEmbedsFullRunIDAndExecSuffix(t *testing.T) {
+	runID := "019f5de4-bfd1-762e-92ed-199c971abcba"
+	execID := "019f5df0-aaaa-bbbb-cccc-abcdef012345"
 
-	if first == second {
-		t.Fatalf("expected distinct job names for distinct task IDs, got %q", first)
+	name := kubernetesTaskJobName(runID, execID)
+	want := "oz-task-019f5de4-bfd1-762e-92ed-199c971abcba-exec-ef012345"
+	if name != want {
+		t.Fatalf("job name = %q, want %q", name, want)
 	}
-	if !strings.HasPrefix(first, "oz-task-task-a-") {
-		t.Fatalf("unexpected job name prefix: %q", first)
+	if !strings.Contains(name, runID) {
+		t.Fatalf("expected full run ID %q in job name %q", runID, name)
 	}
-	if len(first) > 63 {
-		t.Fatalf("job name too long: %d", len(first))
+	if len(name) > 63 {
+		t.Fatalf("job name too long: %d", len(name))
 	}
-	if strings.ContainsAny(first, "_.") {
-		t.Fatalf("job name contains invalid DNS label characters: %q", first)
+	if strings.ContainsAny(name, "_.") {
+		t.Fatalf("job name contains invalid DNS label characters: %q", name)
+	}
+}
+
+func TestKubernetesTaskJobNameFallsBackForEmptyIDs(t *testing.T) {
+	if name := kubernetesTaskJobName("", ""); name != "oz-task-run-exec-exec" {
+		t.Fatalf("job name = %q, want %q", name, "oz-task-run-exec-exec")
+	}
+}
+
+func TestKubernetesTaskJobNameSanitizesIDs(t *testing.T) {
+	// Uppercase and non-DNS characters are lowercased/replaced; short IDs are used in full.
+	if name := kubernetesTaskJobName("RUN_1", "exec.2"); name != "oz-task-run-1-exec-exec-2" {
+		t.Fatalf("job name = %q, want %q", name, "oz-task-run-1-exec-exec-2")
+	}
+}
+
+func TestKubernetesTaskJobNameTruncatesOverlongRunID(t *testing.T) {
+	// A pathologically long run ID is truncated so the Job name fits in 63 chars,
+	// but the execution suffix (the uniqueness discriminator) is preserved.
+	longRunID := strings.Repeat("a", 100)
+	name := kubernetesTaskJobName(longRunID, "019f5df0-aaaa-bbbb-cccc-abcdef012345")
+	if len(name) > 63 {
+		t.Fatalf("job name too long: %d (%q)", len(name), name)
+	}
+	if !strings.HasSuffix(name, "-exec-ef012345") {
+		t.Fatalf("expected execution suffix preserved, got %q", name)
 	}
 }
 
@@ -782,11 +810,11 @@ func TestExecuteTaskUsesImageVolumesForSidecars(t *testing.T) {
 	if createdJob == nil {
 		t.Fatal("expected task job to be created")
 	}
-	if createdJob.Name != sanitizeKubernetesJobName("execution-1") {
-		t.Fatalf("job name = %q, want %q", createdJob.Name, sanitizeKubernetesJobName("execution-1"))
+	if createdJob.Name != kubernetesTaskJobName("task-1", "execution-1") {
+		t.Fatalf("job name = %q, want %q", createdJob.Name, kubernetesTaskJobName("task-1", "execution-1"))
 	}
-	if createdJob.Name == sanitizeKubernetesJobName("task-1") {
-		t.Fatalf("job name should be execution-scoped, got task-scoped name %q", createdJob.Name)
+	if createdJob.Name == kubernetesTaskJobName("task-1", "task-1") {
+		t.Fatalf("job name should include the execution ID, got %q", createdJob.Name)
 	}
 	if createdJob.Labels[kubernetesTaskIDLabel] != "task-1" {
 		t.Fatalf("task label = %q, want %q", createdJob.Labels[kubernetesTaskIDLabel], "task-1")
@@ -944,8 +972,8 @@ func TestExecuteTaskUsesCopyInitContainersByDefault(t *testing.T) {
 	if createdJob == nil {
 		t.Fatal("expected task job to be created")
 	}
-	if createdJob.Name != sanitizeKubernetesJobName("task-1") {
-		t.Fatalf("job name = %q, want %q", createdJob.Name, sanitizeKubernetesJobName("task-1"))
+	if createdJob.Name != kubernetesTaskJobName("task-1", "task-1") {
+		t.Fatalf("job name = %q, want %q", createdJob.Name, kubernetesTaskJobName("task-1", "task-1"))
 	}
 	if createdJob.Labels[kubernetesExecutionIDLabel] != "task-1" {
 		t.Fatalf("fallback execution label = %q, want %q", createdJob.Labels[kubernetesExecutionIDLabel], "task-1")


### PR DESCRIPTION
Customers have asked before about having the run ID in the pod name. I do think this is useful so it's easy to pull worker logs for a run that failed using `kubectl logs`

The downside is the job and pod name will be pretty long, nearing the limit