### PR TITLE
Keep failed k8s jobs and pods around for ttl

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,8 +184,11 @@ task pods independently (for example with separate node pools, selectors,
 tolerations, or disruption budgets) so worker rotation does not imply task pod
 eviction.
 
-When cleanup is enabled, completed task Jobs are still cleaned up by normal
-worker cleanup when observed, with Kubernetes Job TTL as a fallback.
+When cleanup is enabled, successful task Jobs are deleted immediately by the
+worker when it observes completion, while failed task Jobs (and Jobs orphaned by
+worker disruption) are left in place for post-mortem debugging and cleaned up by
+the Kubernetes Job TTL (`kubernetesBackend.ttlSecondsAfterFinished`, default 24h).
+When cleanup is disabled, no TTL is set and task Jobs remain indefinitely.
 
 Recommended namespace-scoped permissions for the worker are:
 

--- a/charts/oz-agent-worker/values.yaml
+++ b/charts/oz-agent-worker/values.yaml
@@ -24,8 +24,8 @@ warp:
     name: oz-agent-worker
     key: WARP_API_KEY
     value: ""
-  webSocketURL: wss://oz.warp.dev/api/v1/selfhosted/worker/ws
-  serverRootURL: https://app.warp.dev
+  webSocketURL: wss://oz.staging.warp.dev/api/v1/selfhosted/worker/ws
+  serverRootURL: https://staging.warp.dev
 
 worker:
   workerId: ""
@@ -83,9 +83,12 @@ kubernetesBackend:
   extraLabels: {}
   extraAnnotations: {}
   activeDeadlineSeconds: null
-  # Fallback cleanup for task Jobs that finish after the worker pod that created
-  # them has been disrupted. When worker.cleanup=false, the worker does not set
-  # a TTL so Jobs remain available for debugging.
+  # How long finished task Jobs that the worker leaves in place are retained before
+  # the Kubernetes Job TTL controller deletes them (and their pods). This covers
+  # failed task Jobs, which are kept for post-mortem debugging, and Jobs orphaned by
+  # worker disruption. Successful task Jobs are deleted immediately by the worker, so
+  # this does not keep them around. Defaults to 24h (86400s). When worker.cleanup=false
+  # the worker sets no TTL, so these Jobs remain indefinitely.
   ttlSecondsAfterFinished: 86400
   workspaceSizeLimit: ""
   unschedulableTimeout: "30s"

--- a/charts/oz-agent-worker/values.yaml
+++ b/charts/oz-agent-worker/values.yaml
@@ -24,8 +24,8 @@ warp:
     name: oz-agent-worker
     key: WARP_API_KEY
     value: ""
-  webSocketURL: wss://oz.staging.warp.dev/api/v1/selfhosted/worker/ws
-  serverRootURL: https://staging.warp.dev
+  webSocketURL: wss://oz.warp.dev/api/v1/selfhosted/worker/ws
+  serverRootURL: https://app.warp.dev
 
 worker:
   workerId: ""

--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -136,7 +136,7 @@ func NewKubernetesBackend(ctx context.Context, config KubernetesBackendConfig) (
 }
 
 // ExecuteTask runs the agent in a Kubernetes Job.
-func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams) error {
+func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams) (retErr error) {
 	if err := validateTaskSidecars(params.Sidecars, b.config.UseImageVolumes); err != nil {
 		return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonSidecarPrep, err)
 	}
@@ -299,19 +299,24 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 		return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonJobCreate, fmt.Errorf("failed to create Kubernetes Job: %w", err))
 	}
 
-	deleted := false
 	defer func() {
-		if deleted {
-			return
-		}
 		if ctx.Err() != nil {
 			log.Infof(ctx, "Leaving Kubernetes Job %s in place after task context cancellation", jobName)
 			return
 		}
-		if !b.config.NoCleanup {
-			if err := b.deleteJob(context.Background(), jobName); err != nil {
-				log.Warnf(ctx, "Failed to delete Job %s: %v", jobName, err)
-			}
+		if b.config.NoCleanup {
+			return
+		}
+		// Preserve failed task Jobs (and their pods) so operators can inspect logs
+		// and pod state after the fact. They are garbage-collected by the Job's
+		// TTLSecondsAfterFinished (see taskJobTTLSecondsAfterFinished). Successful
+		// Jobs are deleted immediately to keep the namespace clean.
+		if retErr != nil {
+			log.Infof(ctx, "Leaving failed Kubernetes Job %s in place for TTL-based cleanup", jobName)
+			return
+		}
+		if err := b.deleteJob(context.Background(), jobName); err != nil {
+			log.Warnf(ctx, "Failed to delete Job %s: %v", jobName, err)
 		}
 	}()
 
@@ -427,6 +432,13 @@ func (b *KubernetesBackend) Shutdown(ctx context.Context) {
 	log.Infof(ctx, "Preserving Kubernetes task Jobs during worker shutdown")
 }
 
+// taskJobTTLSecondsAfterFinished returns the value applied to a task Job's
+// TTLSecondsAfterFinished. It bounds how long finished Jobs that the worker
+// leaves in place - failed Jobs (kept for post-mortem debugging) and Jobs
+// orphaned by worker disruption - and their pods survive before the Kubernetes
+// Job TTL controller deletes them. Successful Jobs are deleted immediately by the
+// worker, so this does not delay their cleanup. Returns nil when cleanup is
+// disabled, so those Jobs are retained indefinitely.
 func (b *KubernetesBackend) taskJobTTLSecondsAfterFinished() *int32 {
 	if b.config.NoCleanup {
 		return nil

--- a/internal/worker/kubernetes_test.go
+++ b/internal/worker/kubernetes_test.go
@@ -1203,6 +1203,148 @@ func TestTaskJobTTLDisabledWhenCleanupDisabled(t *testing.T) {
 	}
 }
 
+func TestTaskJobTTLDefaultsToTwentyFourHours(t *testing.T) {
+	backend := &KubernetesBackend{}
+	ttl := backend.taskJobTTLSecondsAfterFinished()
+	if ttl == nil {
+		t.Fatal("expected non-nil ttlSecondsAfterFinished by default")
+	}
+	if *ttl != int32(24*60*60) {
+		t.Fatalf("expected default ttlSecondsAfterFinished of 24h (86400), got %d", *ttl)
+	}
+}
+
+// On success the worker actively deletes the task Job (and its pod) so the
+// namespace stays clean.
+func TestExecuteTaskDeletesJobOnSuccess(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	jobWatch := watch.NewFake()
+	podWatch := watch.NewFake()
+	defer jobWatch.Stop()
+	defer podWatch.Stop()
+
+	var createdJob *batchv1.Job
+	fakeClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateActionImpl)
+		if !ok {
+			t.Fatalf("expected create action, got %T", action)
+		}
+		job, ok := createAction.GetObject().(*batchv1.Job)
+		if !ok {
+			t.Fatalf("expected Job object, got %T", createAction.GetObject())
+		}
+		createdJob = job.DeepCopy()
+		return false, nil, nil
+	})
+	fakeClient.PrependWatchReactor("jobs", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			if createdJob == nil {
+				return
+			}
+			completed := createdJob.DeepCopy()
+			completed.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+			}
+			jobWatch.Modify(completed)
+		}()
+		return true, jobWatch, nil
+	})
+	fakeClient.PrependWatchReactor("pods", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		return true, podWatch, nil
+	})
+
+	backend := &KubernetesBackend{
+		config: KubernetesBackendConfig{
+			WorkerID:  "worker-123",
+			Namespace: "agents",
+		},
+		clientset: fakeClient,
+	}
+
+	if err := backend.ExecuteTask(context.Background(), &TaskParams{
+		TaskID:      "task-1",
+		DockerImage: "ubuntu:22.04",
+		BaseArgs:    []string{"run"},
+	}); err != nil {
+		t.Fatalf("unexpected ExecuteTask error: %v", err)
+	}
+
+	jobs, err := fakeClient.BatchV1().Jobs("agents").List(context.Background(), metav1.ListOptions{})
+	if err != nil {
+		t.Fatalf("failed to list jobs: %v", err)
+	}
+	if len(jobs.Items) != 0 {
+		t.Fatalf("expected successful task Job to be deleted, got %d", len(jobs.Items))
+	}
+}
+
+// On failure the worker leaves the task Job (and its pod) in place so it can be
+// inspected; the Job's TTLSecondsAfterFinished handles eventual cleanup.
+func TestExecuteTaskPreservesJobOnFailure(t *testing.T) {
+	fakeClient := fake.NewSimpleClientset()
+	jobWatch := watch.NewFake()
+	podWatch := watch.NewFake()
+	defer jobWatch.Stop()
+	defer podWatch.Stop()
+
+	var createdJob *batchv1.Job
+	fakeClient.PrependReactor("create", "jobs", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		createAction, ok := action.(k8stesting.CreateActionImpl)
+		if !ok {
+			t.Fatalf("expected create action, got %T", action)
+		}
+		job, ok := createAction.GetObject().(*batchv1.Job)
+		if !ok {
+			t.Fatalf("expected Job object, got %T", createAction.GetObject())
+		}
+		createdJob = job.DeepCopy()
+		return false, nil, nil
+	})
+	fakeClient.PrependWatchReactor("jobs", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			if createdJob == nil {
+				return
+			}
+			failed := createdJob.DeepCopy()
+			failed.Status.Conditions = []batchv1.JobCondition{
+				{Type: batchv1.JobFailed, Status: corev1.ConditionTrue, Reason: "BackoffLimitExceeded"},
+			}
+			jobWatch.Modify(failed)
+		}()
+		return true, jobWatch, nil
+	})
+	fakeClient.PrependWatchReactor("pods", func(action k8stesting.Action) (bool, watch.Interface, error) {
+		return true, podWatch, nil
+	})
+
+	backend := &KubernetesBackend{
+		config: KubernetesBackendConfig{
+			WorkerID:  "worker-123",
+			Namespace: "agents",
+		},
+		clientset: fakeClient,
+	}
+
+	err := backend.ExecuteTask(context.Background(), &TaskParams{
+		TaskID:      "task-1",
+		DockerImage: "ubuntu:22.04",
+		BaseArgs:    []string{"run"},
+	})
+	if err == nil {
+		t.Fatal("expected ExecuteTask to return an error for a failed Job")
+	}
+
+	jobs, listErr := fakeClient.BatchV1().Jobs("agents").List(context.Background(), metav1.ListOptions{})
+	if listErr != nil {
+		t.Fatalf("failed to list jobs: %v", listErr)
+	}
+	if len(jobs.Items) != 1 {
+		t.Fatalf("expected failed task Job to be preserved, got %d", len(jobs.Items))
+	}
+}
+
 func TestRunStartupPreflightCreatesLegacyRootInitJobAndWaitsForPodCreationByDefault(t *testing.T) {
 	fakeClient := fake.NewSimpleClientset()
 	const preflightImage = "registry.internal/platform/preflight:1.0"


### PR DESCRIPTION
When jobs/pods failed, they were deleted immediately. This leaves no window for debugging or viewing the pod logs.
Instead, we keep failed jobs/pods around to be cleaned up after the `ttlSecondsAfterFinished`. Successful jobs and pods are still cleaned up immediately.