### PR TITLE
Reduce OOM-kill risk for oz agent process in direct backend (REMOTE-2166)

### DIFF
--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -109,6 +109,7 @@ const (
 	TaskFailureReasonWorkspaceSetup  = "workspace_setup"
 	TaskFailureReasonSetupCommand    = "setup_command"
 	TaskFailureReasonAgentInvocation = "agent_invocation"
+	TaskFailureReasonAgentOOM        = "agent_oom"
 	TaskFailureReasonTeardownCommand = "teardown_command"
 	TaskFailureReasonJobCreate       = "job_create"
 	TaskFailureReasonJobWatch        = "job_watch"
@@ -147,6 +148,7 @@ var (
 		TaskFailureReasonWorkspaceSetup,
 		TaskFailureReasonSetupCommand,
 		TaskFailureReasonAgentInvocation,
+		TaskFailureReasonAgentOOM,
 		TaskFailureReasonTeardownCommand,
 		TaskFailureReasonJobCreate,
 		TaskFailureReasonJobWatch,

--- a/internal/worker/direct.go
+++ b/internal/worker/direct.go
@@ -2,11 +2,13 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	"github.com/joho/godotenv"
 	"github.com/warpdotdev/oz-agent-worker/internal/log"
@@ -15,6 +17,14 @@ import (
 )
 
 const defaultWorkspaceRoot = "/var/lib/oz/workspaces"
+
+// oomScoreAdjOzAgent is the OOM score adjustment applied to the oz agent
+// process after it is spawned. A negative value makes the process less likely
+// to be OOM-killed by the kernel, so memory-hungry child processes (e.g.
+// `cargo build`) are targeted first. The range is [-1000, 1000]; negative
+// values require CAP_SYS_RESOURCE. This adjustment is best-effort: if the
+// worker lacks the capability, a warning is logged and execution continues.
+const oomScoreAdjOzAgent = -300
 
 // validateTaskIDForPath ensures task IDs are safe to use as a single path component.
 func validateTaskIDForPath(taskID string) error {
@@ -234,11 +244,24 @@ func (b *DirectBackend) ExecuteTask(ctx context.Context, params *TaskParams) err
 	log.Infof(ctx, "Running oz agent in workspace %s", workspaceDir)
 	log.Debugf(ctx, "Command: %s %s", b.ozPath, strings.Join(params.BaseArgs, " "))
 
-	if err := cmd.Run(); err != nil {
+	if err := cmd.Start(); err != nil {
 		if ctx.Err() != nil {
 			return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonTaskCancelled, ctx.Err())
 		}
-		return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonAgentInvocation, fmt.Errorf("oz agent exited with error: %w", err))
+		return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonAgentInvocation, fmt.Errorf("oz agent failed to start: %w", err))
+	}
+
+	// Protect the oz agent process from OOM killing. Child processes that the
+	// agent spawns (e.g. cargo build) may use far more memory and should be
+	// targeted by the kernel's OOM killer first.
+	setOOMScoreAdj(ctx, cmd.Process.Pid, oomScoreAdjOzAgent)
+
+	if err := cmd.Wait(); err != nil {
+		if ctx.Err() != nil {
+			return newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonTaskCancelled, ctx.Err())
+		}
+		reason, msg := classifyAgentExitError(ctx, err)
+		return newBackendFailure(metrics.TaskFailurePhaseBackend, reason, fmt.Errorf("%s: %w", msg, err))
 	}
 
 	log.Infof(ctx, "Task %s execution completed successfully", taskID)
@@ -304,6 +327,49 @@ func (b *DirectBackend) cleanup(ctx context.Context, taskID, workspaceDir, gitCo
 		)
 		log.Warnf(ctx, "Failed to remove workspace %s: %v", workspaceDir, err)
 	}
+}
+
+// setOOMScoreAdj writes the Linux OOM score adjustment for the given pid.
+// A negative score makes the process less likely to be OOM-killed; writing
+// negative values requires CAP_SYS_RESOURCE. This function is best-effort:
+// on non-Linux systems or when the worker lacks the required capability, the
+// error is logged as a warning and execution continues uninterrupted.
+func setOOMScoreAdj(ctx context.Context, pid int, score int) {
+	path := fmt.Sprintf("/proc/%d/oom_score_adj", pid)
+	data := fmt.Sprintf("%d\n", score)
+	if err := os.WriteFile(path, []byte(data), 0o644); err != nil {
+		log.Warnf(ctx, "Failed to set OOM score adj for oz agent (pid %d) to %d: %v"+
+			" — the agent process is unprotected from OOM killing", pid, score, err)
+		return
+	}
+	log.Infof(ctx, "Set OOM score adj for oz agent (pid %d) to %d"+
+		" (child processes that use more memory will be killed first)", pid, score)
+}
+
+// classifyAgentExitError inspects the exit error of the oz agent process and
+// returns the appropriate failure reason constant and a user-facing message.
+// It detects SIGKILL exits, which may indicate the oz agent process itself was
+// OOM-killed, and records a dedicated span event for observability.
+func classifyAgentExitError(ctx context.Context, err error) (reason, message string) {
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok {
+			if status.Signaled() && status.Signal() == syscall.SIGKILL {
+				log.Errorf(ctx, "oz agent process was killed by SIGKILL — possible OOM kill.\n"+
+					"Hint: the kernel may have targeted the agent process instead of a memory-hungry\n"+
+					"child (e.g. `cargo build`). Check kernel logs (dmesg) for OOM kill events.")
+				metrics.AddTaskEvent(ctx, "agent.sigkill_detected",
+					attribute.String("signal", "SIGKILL"),
+					attribute.String("hint", "possible_oom_kill"),
+				)
+				return metrics.TaskFailureReasonAgentOOM,
+					"The agent process was unexpectedly killed (SIGKILL — possible out-of-memory)." +
+						" Check VM memory usage and kernel OOM logs (dmesg). Consider reducing" +
+						" parallelism (e.g. CARGO_BUILD_JOBS=1) or increasing available memory."
+			}
+		}
+	}
+	return metrics.TaskFailureReasonAgentInvocation, "oz agent exited with error"
 }
 
 // runCommand executes a shell command with the given working directory and environment.

--- a/internal/worker/errors.go
+++ b/internal/worker/errors.go
@@ -47,11 +47,16 @@ func taskFailureLabels(err error) (phase, reason string) {
 // failure. Well-known infrastructure errors (context cancellation, deadline exceeded)
 // are translated into clear, actionable messages instead of exposing raw Go error strings.
 func userFacingTaskError(err error) string {
+	var failure *backendFailureError
 	switch {
 	case errors.Is(err, context.Canceled):
 		return "The task was interrupted due to an infrastructure issue (context canceled). This is typically transient — please try again."
 	case errors.Is(err, context.DeadlineExceeded):
 		return "The task exceeded its maximum allowed execution time and was terminated. Consider breaking the task into smaller steps or increasing the timeout."
+	case errors.As(err, &failure) && failure.reason == metrics.TaskFailureReasonAgentOOM:
+		return "The agent process was unexpectedly killed (possible out-of-memory)." +
+			" Check VM memory usage and kernel OOM logs (dmesg)." +
+			" Consider reducing parallelism (e.g. CARGO_BUILD_JOBS=1) or increasing available memory."
 	default:
 		return fmt.Sprintf("Failed to execute task: %v", err)
 	}

--- a/main.go
+++ b/main.go
@@ -20,6 +20,27 @@ import (
 	sigsk8syaml "sigs.k8s.io/yaml"
 )
 
+// workerOOMScoreAdj is the OOM score adjustment applied to the worker process
+// itself at startup. A negative value makes this long-lived process less likely
+// to be OOM-killed, protecting task lifecycle management and server reconnects.
+// Writing negative values requires CAP_SYS_RESOURCE; the adjustment is
+// best-effort and execution continues unaffected if the capability is missing.
+const workerOOMScoreAdj = -500
+
+// protectWorkerFromOOM writes a protective OOM score adjustment for the
+// current process. It is best-effort: failures are logged and silently ignored
+// so the worker continues normally even when the capability is unavailable
+// (e.g. running as a non-privileged user without CAP_SYS_RESOURCE).
+func protectWorkerFromOOM(ctx context.Context) {
+	data := fmt.Sprintf("%d\n", workerOOMScoreAdj)
+	if err := os.WriteFile("/proc/self/oom_score_adj", []byte(data), 0o644); err != nil {
+		log.Warnf(ctx, "Failed to set worker OOM score adj to %d: %v"+
+			" — the worker process is unprotected from OOM killing", workerOOMScoreAdj, err)
+		return
+	}
+	log.Infof(ctx, "Set worker OOM score adj to %d (worker process is less likely to be OOM-killed)", workerOOMScoreAdj)
+}
+
 // Version is the build-time version string. Override at link time with
 // -ldflags="-X main.Version=...".
 var Version = "dev"
@@ -52,6 +73,11 @@ func main() {
 	)
 
 	log.SetLevel(CLI.LogLevel)
+
+	// Protect the worker process itself from OOM killing. The worker manages
+	// task lifecycle and reconnects to the server; losing it is more disruptive
+	// than an individual oz agent process being killed.
+	protectWorkerFromOOM(ctx)
 
 	// Parse config file if provided.
 	var fileConfig *config.FileConfig


### PR DESCRIPTION
## Problem

Cloud agent runs were going silent for ~1 hour. The hypothesis (REMOTE-2166): the Linux OOM killer was targeting the `oz agent` process (the coordinator) instead of its memory-hungry child processes (e.g. `cargo build` with `CARGO_BUILD_JOBS=1` still consuming significant memory). Once the agent process was killed, the run went dark until the VM was re-spun and a follow-up message resumed it.

## Changes

### `internal/worker/direct.go`
- Changed `cmd.Run()` to `cmd.Start()` + OOM protection + `cmd.Wait()`.
- After starting the oz agent process, write `oom_score_adj = -300` to `/proc/<pid>/oom_score_adj`. This tells the Linux OOM killer to prefer killing the agent's children (the heavy compilers/tools) over the agent coordinator itself. Requires `CAP_SYS_RESOURCE` for negative values; the call is **best-effort** — a warning is logged if the capability is unavailable and execution continues normally.
- Added `classifyAgentExitError`: detects SIGKILL exits on the oz agent process, logs a prominent error with a `dmesg` investigation hint, and emits an `agent.sigkill_detected` span event with a `possible_oom_kill` hint for tracing.

### `main.go`
- At startup, protect the long-lived worker process itself with `oom_score_adj = -500`. The worker manages task lifecycle and server reconnects; losing it is more disruptive than losing a single oz agent run.
- Same best-effort approach: logs a warning if `CAP_SYS_RESOURCE` is missing.

### `internal/metrics/metrics.go`
- Added `TaskFailureReasonAgentOOM = "agent_oom"` to the bounded failure reason constants and `taskFailureReasons` slice, so SIGKILL exits surface in the `oz_worker_task_failures_total` metric with a distinct `reason` label.

### `internal/worker/errors.go`
- Added a user-facing message for `agent_oom` failures guiding operators to check VM memory (`dmesg`) and reduce build parallelism (`CARGO_BUILD_JOBS=1`).

## Notes

- **Capability requirement**: Negative `oom_score_adj` values require `CAP_SYS_RESOURCE`. Warp's own factory VMs should have this; self-hosted workers running as non-root without the capability will see a warning log but are otherwise unaffected.
- This change addresses the direct backend. The Docker/Kubernetes backends are unaffected (Docker already tracks `OOMKilled` via the container state; Kubernetes handles OOM at the cgroup/pod level).
- The oz CLI itself would ideally raise the OOM score of its own spawned tool children (e.g. `cargo build`) — that would give even stronger protection, but requires changes to the oz CLI binary rather than this repo.

_Conversation: https://staging.warp.dev/conversation/f2fe5d7a-21e4-425b-a07d-e6476974386b_
_Run: https://oz.staging.warp.dev/runs/019f6729-eba5-70ff-908a-7e9a34214faa_

_This PR was generated with [Oz](https://warp.dev/oz)._
