### PR TITLE
Set a default deadline of 8 hrs for pods, instead of unbounded

### DIFF
--- a/charts/oz-agent-worker/values.yaml
+++ b/charts/oz-agent-worker/values.yaml
@@ -82,7 +82,12 @@ kubernetesBackend:
   teardownCommand: ""
   extraLabels: {}
   extraAnnotations: {}
-  activeDeadlineSeconds: null
+  # Hard wall-clock cap on how long a single task Job (and its pod) may run
+  # before Kubernetes terminates it and marks the Job failed with a
+  # DeadlineExceeded condition. This is a safety backstop against tasks whose
+  # process never exits, so worker pods cannot linger indefinitely.
+  # Defaults to 8h (28800s); set to null to disable the cap.
+  activeDeadlineSeconds: 28800
   # How long finished task Jobs that the worker leaves in place are retained before
   # the Kubernetes Job TTL controller deletes them (and their pods). This covers
   # failed task Jobs, which are kept for post-mortem debugging, and Jobs orphaned by


### PR DESCRIPTION
I saw some lingering pods that were running forever because they were using 3p harness and there was an error that we weren't capturing. The process never exited. Seems more reasonable to have a default timeout