### PR TITLE
Add sandbox startup failure observability and improve error messages (REMOTE-2210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,13 @@ shows up as a distinct series.
   classification for task failures, such as `phase="backend"` with
   `reason="image_pull"`, `reason="unschedulable"`, or
   `reason="container_oom"`.
+- `oz_worker_task_sandbox_startup_failures_total{reason}` (counter): task
+  failures that occurred within the first 5 minutes of task assignment,
+  labeled by failure reason. A sustained increase indicates systemic sandbox
+  startup issues such as slow image pulls, cluster resource pressure, or
+  admission failures. This counter is a subset of `oz_worker_task_failures_total`
+  and is intended to help triage startup-specific regressions separately from
+  long-running task failures.
 - `oz_worker_websocket_reconnects_total{reason}` (counter): reconnect
   attempts; spikes indicate flapping workers.
 - `oz_worker_info{version,backend,worker_id}` (gauge, value `1`): build and
@@ -386,6 +393,12 @@ Direct mappings for the questions enterprise operators most commonly ask:
   `sum by (phase, reason) (rate(oz_worker_task_failures_total[5m]))`
 - **Reconnect storms:**
   `sum(rate(oz_worker_websocket_reconnects_total[5m])) > 0.1`
+- **Sandbox startup failures:**
+  `sum(rate(oz_worker_task_sandbox_startup_failures_total[5m])) > 0`
+  Broken down by reason:
+  `sum by (reason) (rate(oz_worker_task_sandbox_startup_failures_total[5m]))`
+  Alert when `reason="active_deadline"` or `reason="image_pull"` are non-zero
+  to catch systemic provisioning regressions early.
 
 ## License
 

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -67,16 +67,17 @@ type Config struct {
 // a single MeterProvider. Helpers read this struct atomically so that Init can
 // hot-swap from the no-op set to the SDK-backed set without locking.
 type instruments struct {
-	connected          metric.Int64Gauge
-	tasksActive        metric.Int64UpDownCounter
-	tasksMaxConcurrent metric.Int64Gauge
-	tasksClaimed       metric.Int64Counter
-	tasksRejected      metric.Int64Counter
-	tasksCompleted     metric.Int64Counter
-	taskDuration       metric.Float64Histogram
-	taskFailures       metric.Int64Counter
-	wsReconnects       metric.Int64Counter
-	workerInfo         metric.Int64Gauge
+	connected                  metric.Int64Gauge
+	tasksActive                metric.Int64UpDownCounter
+	tasksMaxConcurrent         metric.Int64Gauge
+	tasksClaimed               metric.Int64Counter
+	tasksRejected              metric.Int64Counter
+	tasksCompleted             metric.Int64Counter
+	taskDuration               metric.Float64Histogram
+	taskFailures               metric.Int64Counter
+	wsReconnects               metric.Int64Counter
+	workerInfo                 metric.Int64Gauge
+	sandboxStartupFailures     metric.Int64Counter
 }
 
 // activeInstruments is the current instrument set. It always points to a
@@ -295,6 +296,11 @@ func primeInstruments(ctx context.Context, set *instruments) {
 			)
 		}
 	}
+	for _, reason := range taskFailureReasons {
+		set.sandboxStartupFailures.Add(ctx, 0,
+			metric.WithAttributes(attribute.String("reason", reason)),
+		)
+	}
 	for _, r := range []string{WSReconnectReasonDialFailed, WSReconnectReasonRemoteClose} {
 		set.wsReconnects.Add(ctx, 0,
 			metric.WithAttributes(attribute.String("reason", r)),
@@ -394,17 +400,25 @@ func buildInstruments(m metric.Meter) (*instruments, error) {
 	if err != nil {
 		return nil, err
 	}
+	sandboxStartupFailures, err := m.Int64Counter(
+		"oz_worker_task_sandbox_startup_failures_total",
+		metric.WithDescription("Task failures that occurred within the sandbox startup window, labeled by failure reason. A spike indicates systemic sandbox provisioning or image-pull issues."),
+	)
+	if err != nil {
+		return nil, err
+	}
 	return &instruments{
-		connected:          connected,
-		tasksActive:        tasksActive,
-		tasksMaxConcurrent: tasksMaxConcurrent,
-		tasksClaimed:       tasksClaimed,
-		tasksRejected:      tasksRejected,
-		tasksCompleted:     tasksCompleted,
-		taskDuration:       taskDuration,
-		taskFailures:       taskFailures,
-		wsReconnects:       wsReconnects,
-		workerInfo:         workerInfo,
+		connected:              connected,
+		tasksActive:            tasksActive,
+		tasksMaxConcurrent:     tasksMaxConcurrent,
+		tasksClaimed:           tasksClaimed,
+		tasksRejected:          tasksRejected,
+		tasksCompleted:         tasksCompleted,
+		taskDuration:           taskDuration,
+		taskFailures:           taskFailures,
+		wsReconnects:           wsReconnects,
+		workerInfo:             workerInfo,
+		sandboxStartupFailures: sandboxStartupFailures,
 	}, nil
 }
 
@@ -485,6 +499,16 @@ func RecordTaskFailure(phase, reason string) {
 // (e.g. "dial_failed", "remote_close").
 func RecordWebsocketReconnect(reason string) {
 	current().wsReconnects.Add(context.Background(), 1,
+		metric.WithAttributes(attribute.String("reason", reason)),
+	)
+}
+
+// RecordSandboxStartupFailure records a task failure that occurred within the
+// sandbox startup window. reason should be one of the TaskFailureReason* constants.
+// A sustained increase in this counter indicates systemic sandbox startup issues
+// such as slow image pulls, cluster resource pressure, or admission failures.
+func RecordSandboxStartupFailure(reason string) {
+	current().sandboxStartupFailures.Add(context.Background(), 1,
 		metric.WithAttributes(attribute.String("reason", reason)),
 	)
 }

--- a/internal/metrics/metrics_test.go
+++ b/internal/metrics/metrics_test.go
@@ -85,6 +85,7 @@ func TestHelpersSafeBeforeInit(t *testing.T) {
 	RecordTaskCompleted(TaskResultFailed, 1*time.Second)
 	RecordTaskCompleted(TaskResultCancelled, 500*time.Millisecond)
 	RecordTaskFailure(TaskFailurePhaseBackend, TaskFailureReasonImagePull)
+	RecordSandboxStartupFailure(TaskFailureReasonActiveDeadline)
 	RecordWebsocketReconnect("dial_failed")
 	SetWorkerInfo("v0.0.0", "docker", "test")
 	ctx, span := StartTaskSpan(context.Background(), "task-1", "test task")
@@ -252,6 +253,7 @@ func TestPrimeInstrumentsExposesAllSeriesAtStartup(t *testing.T) {
 		"oz_worker_tasks_completed_total",
 		"oz_worker_task_failures_total",
 		"oz_worker_websocket_reconnects_total",
+		"oz_worker_task_sandbox_startup_failures_total",
 	}
 	for _, name := range want {
 		findMetric(t, rm, name) // fails the test if missing
@@ -333,6 +335,32 @@ func TestPrimeInstrumentsExposesAllSeriesAtStartup(t *testing.T) {
 				t.Errorf("oz_worker_task_duration_seconds was emitted at startup; expected to remain absent until first task")
 			}
 		}
+	}
+}
+
+func TestRecordSandboxStartupFailureTagsReason(t *testing.T) {
+	reader := withTestReader(t, Config{WorkerID: "w1", Backend: "kubernetes"})
+
+	RecordSandboxStartupFailure(TaskFailureReasonActiveDeadline)
+	RecordSandboxStartupFailure(TaskFailureReasonActiveDeadline)
+	RecordSandboxStartupFailure(TaskFailureReasonImagePull)
+
+	rm := collect(t, reader)
+	startupFailures := findMetric(t, rm, "oz_worker_task_sandbox_startup_failures_total")
+	sum, ok := startupFailures.Data.(metricdata.Sum[int64])
+	if !ok {
+		t.Fatalf("expected Sum[int64], got %T", startupFailures.Data)
+	}
+	byReason := map[string]int64{}
+	for _, dp := range sum.DataPoints {
+		v, _ := dp.Attributes.Value("reason")
+		byReason[v.AsString()] = dp.Value
+	}
+	if got := byReason[TaskFailureReasonActiveDeadline]; got != 2 {
+		t.Errorf("active_deadline count = %d, want 2", got)
+	}
+	if got := byReason[TaskFailureReasonImagePull]; got != 1 {
+		t.Errorf("image_pull count = %d, want 1", got)
 	}
 }
 

--- a/internal/worker/errors.go
+++ b/internal/worker/errors.go
@@ -44,8 +44,9 @@ func taskFailureLabels(err error) (phase, reason string) {
 }
 
 // userFacingTaskError returns a user-friendly error message for a task execution
-// failure. Well-known infrastructure errors (context cancellation, deadline exceeded)
-// are translated into clear, actionable messages instead of exposing raw Go error strings.
+// failure. Well-known infrastructure errors (context cancellation, deadline exceeded,
+// and specific backend failure reasons) are translated into clear, actionable messages
+// instead of exposing raw Go error strings.
 func userFacingTaskError(err error) string {
 	switch {
 	case errors.Is(err, context.Canceled):
@@ -53,6 +54,23 @@ func userFacingTaskError(err error) string {
 	case errors.Is(err, context.DeadlineExceeded):
 		return "The task exceeded its maximum allowed execution time and was terminated. Consider breaking the task into smaller steps or increasing the timeout."
 	default:
+		var failure *backendFailureError
+		if errors.As(err, &failure) {
+			switch failure.reason {
+			case metrics.TaskFailureReasonActiveDeadline:
+				return "The agent sandbox did not complete before the job deadline was exceeded. This may indicate slow container image pulls, cluster resource pressure, or sandbox startup delays — please try again."
+			case metrics.TaskFailureReasonContainerCreate, metrics.TaskFailureReasonContainerStart:
+				return "The agent sandbox failed to start. This may indicate a container image issue, insufficient cluster resources, or a configuration problem — please try again."
+			case metrics.TaskFailureReasonSidecarPrep:
+				return "The agent sandbox failed to prepare its required dependencies. This may indicate a container image issue or a network connectivity problem — please try again."
+			case metrics.TaskFailureReasonImagePull:
+				return "The agent sandbox could not pull its container image. Verify the image is accessible from the worker and try again."
+			case metrics.TaskFailureReasonUnschedulable:
+				return "The agent sandbox could not be scheduled due to insufficient cluster resources. Check available capacity and try again."
+			case metrics.TaskFailureReasonContainerOOM:
+				return "The agent sandbox ran out of memory and was terminated. Consider breaking the task into smaller steps or requesting a larger runner."
+			}
+		}
 		return fmt.Sprintf("Failed to execute task: %v", err)
 	}
 }

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -31,6 +31,12 @@ const (
 	BackendShutdownTimeout = 10 * time.Second
 
 	warpServerRootURLEnv = "WARP_SERVER_ROOT_URL"
+
+	// sandboxStartupWindow is the duration after task assignment within which a
+	// task failure is classified as a sandbox startup failure. Failures that
+	// occur within this window are likely caused by slow image pulls, container
+	// scheduling delays, or admission failures rather than task-execution errors.
+	sandboxStartupWindow = 5 * time.Minute
 )
 
 type Config struct {
@@ -613,6 +619,17 @@ func (w *Worker) executeTask(ctx context.Context, taskCancel context.CancelFunc,
 		span.RecordError(err)
 		span.SetStatus(codes.Error, reason)
 		log.Errorf(ctx, "Task execution failed: taskID=%s, error=%v", taskID, err)
+		sandboxStartupDuration := time.Since(receivedAt)
+		if sandboxStartupDuration < sandboxStartupWindow {
+			log.Warnf(ctx, "Task failed within sandbox startup window (taskID=%s, duration=%v, failure.phase=%s, failure.reason=%s): possible sandbox startup issue",
+				taskID, sandboxStartupDuration.Round(time.Millisecond), phase, reason)
+			metrics.RecordSandboxStartupFailure(reason)
+			metrics.AddTaskEvent(ctx, "task.sandbox_startup_failure",
+				attribute.String("failure.phase", phase),
+				attribute.String("failure.reason", reason),
+				attribute.Float64("startup.duration_seconds", sandboxStartupDuration.Seconds()),
+			)
+		}
 		if statusErr := w.sendTaskFailed(taskID, userFacingTaskError(err)); statusErr != nil {
 			log.Errorf(ctx, "Failed to send task failed message: %v", statusErr)
 		}

--- a/internal/worker/worker_test.go
+++ b/internal/worker/worker_test.go
@@ -324,6 +324,78 @@ func TestUserFacingTaskError(t *testing.T) {
 			err:  errors.New("boom"),
 			want: "Failed to execute task: boom",
 		},
+		{
+			name: "active deadline backend failure",
+			err: newBackendFailure(
+				metrics.TaskFailurePhaseBackend,
+				metrics.TaskFailureReasonActiveDeadline,
+				errors.New("job deadline exceeded"),
+			),
+			want: "The agent sandbox did not complete before the job deadline was exceeded. This may indicate slow container image pulls, cluster resource pressure, or sandbox startup delays — please try again.",
+		},
+		{
+			name: "container start backend failure",
+			err: newBackendFailure(
+				metrics.TaskFailurePhaseBackend,
+				metrics.TaskFailureReasonContainerStart,
+				errors.New("failed to start container"),
+			),
+			want: "The agent sandbox failed to start. This may indicate a container image issue, insufficient cluster resources, or a configuration problem — please try again.",
+		},
+		{
+			name: "container create backend failure",
+			err: newBackendFailure(
+				metrics.TaskFailurePhaseBackend,
+				metrics.TaskFailureReasonContainerCreate,
+				errors.New("failed to create container"),
+			),
+			want: "The agent sandbox failed to start. This may indicate a container image issue, insufficient cluster resources, or a configuration problem — please try again.",
+		},
+		{
+			name: "sidecar prep backend failure",
+			err: newBackendFailure(
+				metrics.TaskFailurePhaseBackend,
+				metrics.TaskFailureReasonSidecarPrep,
+				errors.New("sidecar prep failed"),
+			),
+			want: "The agent sandbox failed to prepare its required dependencies. This may indicate a container image issue or a network connectivity problem — please try again.",
+		},
+		{
+			name: "image pull backend failure",
+			err: newBackendFailure(
+				metrics.TaskFailurePhaseBackend,
+				metrics.TaskFailureReasonImagePull,
+				errors.New("pull failed"),
+			),
+			want: "The agent sandbox could not pull its container image. Verify the image is accessible from the worker and try again.",
+		},
+		{
+			name: "unschedulable backend failure",
+			err: newBackendFailure(
+				metrics.TaskFailurePhaseBackend,
+				metrics.TaskFailureReasonUnschedulable,
+				errors.New("pod unschedulable"),
+			),
+			want: "The agent sandbox could not be scheduled due to insufficient cluster resources. Check available capacity and try again.",
+		},
+		{
+			name: "container OOM backend failure",
+			err: newBackendFailure(
+				metrics.TaskFailurePhaseBackend,
+				metrics.TaskFailureReasonContainerOOM,
+				errors.New("oom killed"),
+			),
+			want: "The agent sandbox ran out of memory and was terminated. Consider breaking the task into smaller steps or requesting a larger runner.",
+		},
+		{
+			name: "wrapped backend failure preserves reason-specific message",
+			err: fmt.Errorf("outer: %w", newBackendFailure(
+				metrics.TaskFailurePhaseBackend,
+				metrics.TaskFailureReasonImagePull,
+				errors.New("pull failed"),
+			)),
+			want: "The agent sandbox could not pull its container image. Verify the image is accessible from the worker and try again.",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Addresses [REMOTE-2210](https://linear.app/warp/issue/REMOTE-2210): Cloud agent sandbox fails to start before startup deadline.

### Changes

**1. New metric: `oz_worker_task_sandbox_startup_failures_total{reason}`**

Tracks task failures that occur within the first 5 minutes of task assignment, labeled by failure reason. This counter is a subset of `oz_worker_task_failures_total` designed to isolate systemic sandbox provisioning issues (slow image pulls, cluster resource pressure, admission failures) from long-running task errors. The metric is primed at startup so dashboards and alerts can query it immediately.

Recommended PromQL alert:
```
sum by (reason) (rate(oz_worker_task_sandbox_startup_failures_total[5m])) > 0
```

**2. Startup window failure detection in `executeTask`**

When a task fails within the `sandboxStartupWindow` (5 min), the worker now:
- Emits a `Warn`-level log with task ID, elapsed duration, failure phase, and reason
- Records a `task.sandbox_startup_failure` trace event with those same attributes
- Increments the new `oz_worker_task_sandbox_startup_failures_total` counter

**3. Improved user-facing error messages**

`userFacingTaskError` now produces actionable, reason-specific messages for known `backendFailureError` types instead of always falling back to the raw `"Failed to execute task: ..."` string. Covered reasons:

| Reason | New message |
|---|---|
| `active_deadline` | "The agent sandbox did not complete before the job deadline was exceeded. This may indicate slow container image pulls, cluster resource pressure, or sandbox startup delays — please try again." |
| `container_create` / `container_start` | "The agent sandbox failed to start. This may indicate a container image issue, insufficient cluster resources, or a configuration problem — please try again." |
| `sidecar_prep` | "The agent sandbox failed to prepare its required dependencies..." |
| `image_pull` | "The agent sandbox could not pull its container image..." |
| `unschedulable` | "The agent sandbox could not be scheduled due to insufficient cluster resources..." |
| `container_oom` | "The agent sandbox ran out of memory and was terminated..." |

**4. README documentation**

Added the new metric to the catalog and sample dashboards/alerts section.

---

_Conversation: https://staging.warp.dev/conversation/3785204b-d602-4fb7-8a4f-e8a0d934d721_
_Run: https://oz.staging.warp.dev/runs/019f71e6-7b6c-7eed-95ef-49206074f37f_

_This PR was generated with [Oz](https://warp.dev/oz)._
