### PR TITLE
direct backend: add harness_config_dirs for seeding Claude/Codex local configs (REMOTE-2316)

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,112 @@ Direct mappings for the questions enterprise operators most commonly ask:
 - **Reconnect storms:**
   `sum(rate(oz_worker_websocket_reconnects_total[5m])) > 0.1`
 
+## Claude Code harness: local plugins and settings
+
+When a task runs with the Claude Code (`claude`) or Codex (`codex`) harness, the
+worker isolates each task's harness config into a per-task subdirectory (e.g.
+`<workspace>/.claude` with `CLAUDE_CONFIG_DIR` pointing at it). This prevents
+concurrent tasks from interfering with each other but means the task starts with
+an empty config directory — local plugins, skills, and user settings are not
+automatically carried over.
+
+### Direct backend: `harness_config_dirs`
+
+For self-hosted workers using the **direct backend**, set `harness_config_dirs`
+in the worker config file to copy a host directory into each task's harness
+config directory before the task runs:
+
+```yaml
+worker_id: "my-worker"
+backend:
+  direct:
+    workspace_root: "/var/lib/oz/workspaces"
+    oz_path: "/usr/local/bin/oz"
+    harness_config_dirs:
+      claude: "/home/operator/.claude"  # seed from host ~/.claude into each task's CLAUDE_CONFIG_DIR
+      codex:  "/home/operator/.codex"   # similarly for Codex
+```
+
+The host directory is **copied** (not mounted), so each task gets its own
+isolated copy and writes do not accumulate back on the host. If the host
+directory does not exist the seed step is silently skipped, so you can configure
+the path before installing Claude Code.
+
+> **Note:** The seeded copy is per-task and discarded after the task completes.
+> Any state Claude Code writes during a task (conversation history, cached
+> credentials) stays in the workspace and is removed on cleanup.
+
+### Docker backend: volume mounts
+
+For the **Docker backend**, Claude Code uses `~/.claude` inside the container
+(the `CLAUDE_CONFIG_DIR` variable is not explicitly set). Mount your local
+Claude config directory as a read-only bind mount:
+
+```yaml
+worker_id: "my-worker"
+backend:
+  docker:
+    volumes:
+      - "/home/operator/.claude:/root/.claude:ro"
+```
+
+Adjust the target path (`/root/.claude`) to match the `HOME` of the user that
+Claude Code runs as inside the task image.
+
+### Kubernetes backend: PVC or custom sidecar
+
+For the **Kubernetes backend** there are two recommended approaches:
+
+**Option A – PersistentVolumeClaim:** Mount a PVC containing your Claude config
+into each task pod via `backend.kubernetes.pod_template`:
+
+```yaml
+backend:
+  kubernetes:
+    pod_template:
+      volumes:
+        - name: claude-config
+          persistentVolumeClaim:
+            claimName: claude-config-pvc
+      containers:
+        - name: task
+          env:
+            - name: CLAUDE_CONFIG_DIR
+              value: /mnt/claude-config
+          volumeMounts:
+            - name: claude-config
+              mountPath: /mnt/claude-config
+              readOnly: true
+```
+
+**Option B – Custom sidecar image:** Build a Docker image that has your plugins
+pre-installed and configure it as a custom coding CLI sidecar. Because the
+bundled sidecar already carries the `claude` binary, you can layer your plugins
+on top of it:
+
+```yaml
+backend:
+  kubernetes:
+    coding_cli_sidecars:
+      claude: "registry.internal.example.com/claude-with-plugins:v1"
+```
+
+The image must expose the `claude` binary in the path the Warp entrypoint
+expects. Plugins baked into the sidecar image are available to every task that
+uses the Claude Code harness on this worker.
+
+### Warp-managed cloud environments
+
+For Warp-managed cloud environments (not self-hosted) there is no direct way to
+transfer local per-user Claude Code plugins and settings today. The current
+alternatives are:
+
+- **Plugin Marketplace plugins:** Plugins installed from Claude's Plugin
+  Marketplace are applied by Warp automatically via the official sidecar image.
+- **Team-shared plugins:** If your team uses the same set of plugins, build a
+  custom Docker image that includes them and configure it as a
+  `coding_cli_sidecars` entry in a self-hosted worker.
+
 ## License
 
 Copyright © 2026 Warp

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,12 +55,26 @@ type DockerConfig struct {
 
 // DirectConfig holds direct-backend-specific configuration.
 type DirectConfig struct {
-	WorkspaceRoot   string     `yaml:"workspace_root"`
-	TargetDir       string     `yaml:"target_dir"`
-	OzPath          string     `yaml:"oz_path"`
-	SetupCommand    string     `yaml:"setup_command"`
-	TeardownCommand string     `yaml:"teardown_command"`
-	Environment     []EnvEntry `yaml:"environment" validate:"dive"`
+	WorkspaceRoot   string            `yaml:"workspace_root"`
+	TargetDir       string            `yaml:"target_dir"`
+	OzPath          string            `yaml:"oz_path"`
+	SetupCommand    string            `yaml:"setup_command"`
+	TeardownCommand string            `yaml:"teardown_command"`
+	Environment     []EnvEntry        `yaml:"environment" validate:"dive"`
+	// HarnessConfigDirs maps a harness name (e.g. "claude", "codex") to a host
+	// directory path. When set, the backend copies the specified host directory
+	// into the workspace's per-task harness config directory before task
+	// execution. This makes local plugins and user settings available to the
+	// harness inside each isolated task workspace.
+	//
+	// If the source directory does not exist the seed step is silently skipped
+	// so that the worker can be configured ahead of any actual plugin install.
+	//
+	// Example:
+	//   harness_config_dirs:
+	//     claude: "/home/operator/.claude"
+	//     codex:  "/home/operator/.codex"
+	HarnessConfigDirs map[string]string `yaml:"harness_config_dirs"`
 }
 
 // KubernetesConfig holds Kubernetes-backend-specific configuration.

--- a/internal/worker/direct.go
+++ b/internal/worker/direct.go
@@ -79,6 +79,15 @@ type DirectBackendConfig struct {
 	TeardownCommand string
 	NoCleanup       bool
 	Env             map[string]string
+	// HarnessConfigDirs maps a harness name (e.g. "claude", "codex") to a host
+	// directory path. When set, the backend copies the specified host directory
+	// into the workspace's per-task harness config directory before task
+	// execution. This makes local plugins and user settings available to the
+	// harness inside each isolated task workspace.
+	//
+	// If the source directory does not exist the seed step is silently skipped
+	// so that the worker can be configured ahead of any actual plugin install.
+	HarnessConfigDirs map[string]string
 }
 
 // DirectBackend executes tasks directly on the host without Docker.
@@ -190,6 +199,13 @@ func (b *DirectBackend) ExecuteTask(ctx context.Context, params *TaskParams) Exe
 	}
 	envVars = mergeEnvVars(envVars, harnessEnvVars(workspaceDir, params))
 	envVars = mergeEnvVars(envVars, gitConfigEnv)
+
+	// 3a. Seed harness config dir from host if configured.
+	if !usingTargetDir {
+		if err := b.seedHarnessConfigDir(ctx, workspaceDir, params); err != nil {
+			return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonWorkspaceSetup, err))
+		}
+	}
 
 	// 4. Run setup command if configured.
 	if b.config.SetupCommand != "" {
@@ -390,4 +406,48 @@ func harnessEnvVars(workspaceDir string, params *TaskParams) []string {
 		return nil
 	}
 	return []string{fmt.Sprintf("%s=%s", config.configEnvVar, filepath.Join(workspaceDir, config.configDir))}
+}
+
+// seedHarnessConfigDir copies the operator-configured host harness config
+// directory into the task workspace's harness config directory.
+//
+// This lets per-user Claude Code (or Codex) plugins and settings be available
+// in each task's isolated config directory without leaking writes between
+// concurrent tasks.
+//
+// If the configured host directory does not exist the step is silently skipped
+// so that the worker can be configured ahead of any actual plugin install.
+func (b *DirectBackend) seedHarnessConfigDir(ctx context.Context, workspaceDir string, params *TaskParams) error {
+	if len(b.config.HarnessConfigDirs) == 0 ||
+		params == nil ||
+		params.Task == nil ||
+		params.Task.AgentConfigSnapshot == nil ||
+		params.Task.AgentConfigSnapshot.Harness == nil ||
+		params.Task.AgentConfigSnapshot.Harness.Type == nil {
+		return nil
+	}
+
+	harnessType := strings.TrimSpace(*params.Task.AgentConfigSnapshot.Harness.Type)
+	hostSrcDir, ok := b.config.HarnessConfigDirs[harnessType]
+	if !ok || hostSrcDir == "" {
+		return nil
+	}
+
+	harnessConf, ok := harnessConfigs[harnessType]
+	if !ok {
+		return nil
+	}
+
+	// Silently skip when the host source directory does not exist.
+	if _, err := os.Stat(hostSrcDir); os.IsNotExist(err) {
+		log.Infof(ctx, "Harness config dir %q does not exist; skipping seed for harness %q", hostSrcDir, harnessType)
+		return nil
+	}
+
+	destDir := filepath.Join(workspaceDir, harnessConf.configDir)
+	log.Infof(ctx, "Seeding harness config dir for %q from %q into %q", harnessType, hostSrcDir, destDir)
+	if err := os.CopyFS(destDir, os.DirFS(hostSrcDir)); err != nil {
+		return fmt.Errorf("failed to seed harness config dir for %q from %q: %w", harnessType, hostSrcDir, err)
+	}
+	return nil
 }

--- a/internal/worker/direct_test.go
+++ b/internal/worker/direct_test.go
@@ -355,6 +355,169 @@ git config --global --add url."https://x-access-token:tok@github.com/".insteadOf
 	}
 }
 
+func TestSeedHarnessConfigDir(t *testing.T) {
+	// Build a fake oz binary that just exits 0.
+	testDir := t.TempDir()
+	ozPath := filepath.Join(testDir, "oz")
+	if err := os.WriteFile(ozPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("failed to write fake oz script: %v", err)
+	}
+
+	t.Run("seeds harness config dir from host path", func(t *testing.T) {
+		// Create a source directory that mimics a local ~/.claude dir.
+		srcDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(srcDir, "settings.json"), []byte(`{"theme":"dark"}`), 0o600); err != nil {
+			t.Fatalf("failed to write source file: %v", err)
+		}
+		subDir := filepath.Join(srcDir, "plugins")
+		if err := os.MkdirAll(subDir, 0o755); err != nil {
+			t.Fatalf("failed to create plugins dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(subDir, "my-plugin.js"), []byte(`console.log("hi")`), 0o644); err != nil {
+			t.Fatalf("failed to write plugin file: %v", err)
+		}
+
+		workspaceRoot := filepath.Join(testDir, "ws-seed")
+		backend, err := NewDirectBackend(context.Background(), DirectBackendConfig{
+			WorkspaceRoot: workspaceRoot,
+			OzPath:        ozPath,
+			NoCleanup:     true,
+			HarnessConfigDirs: map[string]string{
+				"claude": srcDir,
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed to create backend: %v", err)
+		}
+
+		taskID := "task-harness-seed"
+		harnessType := "claude"
+		if result := backend.ExecuteTask(context.Background(), &TaskParams{
+			TaskID: taskID,
+			Task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					Harness: &types.Harness{Type: &harnessType},
+				},
+			},
+		}); result.Error != nil {
+			t.Fatalf("ExecuteTask failed: %v", result.Error)
+		}
+
+		// Verify the harness config dir was seeded.
+		seededSettings := filepath.Join(workspaceRoot, taskID, ".claude", "settings.json")
+		data, err := os.ReadFile(seededSettings)
+		if err != nil {
+			t.Fatalf("seeded settings.json not found: %v", err)
+		}
+		if string(data) != `{"theme":"dark"}` {
+			t.Fatalf("seeded settings.json content = %q, want %q", string(data), `{"theme":"dark"}`)
+		}
+
+		seededPlugin := filepath.Join(workspaceRoot, taskID, ".claude", "plugins", "my-plugin.js")
+		if _, err := os.Stat(seededPlugin); err != nil {
+			t.Fatalf("seeded plugin file not found: %v", err)
+		}
+	})
+
+	t.Run("skips seed when host dir does not exist", func(t *testing.T) {
+		workspaceRoot := filepath.Join(testDir, "ws-nodir")
+		backend, err := NewDirectBackend(context.Background(), DirectBackendConfig{
+			WorkspaceRoot: workspaceRoot,
+			OzPath:        ozPath,
+			NoCleanup:     true,
+			HarnessConfigDirs: map[string]string{
+				"claude": filepath.Join(testDir, "nonexistent-claude-dir"),
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed to create backend: %v", err)
+		}
+
+		taskID := "task-nodir"
+		harnessType := "claude"
+		if result := backend.ExecuteTask(context.Background(), &TaskParams{
+			TaskID: taskID,
+			Task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					Harness: &types.Harness{Type: &harnessType},
+				},
+			},
+		}); result.Error != nil {
+			t.Fatalf("ExecuteTask should not fail when host harness dir is absent: %v", result.Error)
+		}
+
+		// The .claude dir should not have been created (no files to copy).
+		claudeDir := filepath.Join(workspaceRoot, taskID, ".claude")
+		if _, err := os.Stat(claudeDir); !os.IsNotExist(err) {
+			t.Fatalf(".claude dir should not exist when host dir is absent; stat err = %v", err)
+		}
+	})
+
+	t.Run("no-op when harness type is not in HarnessConfigDirs", func(t *testing.T) {
+		srcDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(srcDir, "settings.json"), []byte(`{}`), 0o600); err != nil {
+			t.Fatalf("failed to write source file: %v", err)
+		}
+
+		workspaceRoot := filepath.Join(testDir, "ws-noop")
+		backend, err := NewDirectBackend(context.Background(), DirectBackendConfig{
+			WorkspaceRoot: workspaceRoot,
+			OzPath:        ozPath,
+			NoCleanup:     true,
+			HarnessConfigDirs: map[string]string{
+				"codex": srcDir, // configured for codex, not claude
+			},
+		})
+		if err != nil {
+			t.Fatalf("failed to create backend: %v", err)
+		}
+
+		taskID := "task-noop-harness"
+		harnessType := "claude"
+		if result := backend.ExecuteTask(context.Background(), &TaskParams{
+			TaskID: taskID,
+			Task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					Harness: &types.Harness{Type: &harnessType},
+				},
+			},
+		}); result.Error != nil {
+			t.Fatalf("ExecuteTask failed: %v", result.Error)
+		}
+
+		// .claude dir should not have been seeded.
+		claudeDir := filepath.Join(workspaceRoot, taskID, ".claude")
+		if _, err := os.Stat(claudeDir); !os.IsNotExist(err) {
+			t.Fatalf(".claude dir should not exist when harness is not configured; stat err = %v", err)
+		}
+	})
+
+	t.Run("no-op when HarnessConfigDirs is nil", func(t *testing.T) {
+		workspaceRoot := filepath.Join(testDir, "ws-nilmap")
+		backend, err := NewDirectBackend(context.Background(), DirectBackendConfig{
+			WorkspaceRoot: workspaceRoot,
+			OzPath:        ozPath,
+			NoCleanup:     true,
+		})
+		if err != nil {
+			t.Fatalf("failed to create backend: %v", err)
+		}
+
+		taskID := "task-nilmap"
+		harnessType := "claude"
+		if result := backend.ExecuteTask(context.Background(), &TaskParams{
+			TaskID: taskID,
+			Task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					Harness: &types.Harness{Type: &harnessType},
+				},
+			},
+		}); result.Error != nil {
+			t.Fatalf("ExecuteTask failed: %v", result.Error)
+		}
+	})
+}
+
 func TestDirectBackendRejectsUnsafeTaskID(t *testing.T) {
 	testDir := t.TempDir()
 	ozPath := filepath.Join(testDir, "oz")

--- a/main.go
+++ b/main.go
@@ -294,12 +294,14 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 		}
 
 		var workspaceRoot, targetDir, ozPath, setupCmd, teardownCmd string
+		var harnessConfigDirs map[string]string
 		if fileConfig != nil && fileConfig.Backend.Direct != nil {
 			workspaceRoot = fileConfig.Backend.Direct.WorkspaceRoot
 			targetDir = fileConfig.Backend.Direct.TargetDir
 			ozPath = fileConfig.Backend.Direct.OzPath
 			setupCmd = fileConfig.Backend.Direct.SetupCommand
 			teardownCmd = fileConfig.Backend.Direct.TeardownCommand
+			harnessConfigDirs = copyStringMap(fileConfig.Backend.Direct.HarnessConfigDirs)
 		}
 
 		// CLI --target-dir overrides config file.
@@ -308,13 +310,14 @@ func mergeConfig(fileConfig *config.FileConfig) (worker.Config, error) {
 		}
 
 		wc.Direct = &worker.DirectBackendConfig{
-			WorkspaceRoot:   workspaceRoot,
-			TargetDir:       targetDir,
-			OzPath:          ozPath,
-			SetupCommand:    setupCmd,
-			TeardownCommand: teardownCmd,
-			NoCleanup:       noCleanup,
-			Env:             mergedEnv,
+			WorkspaceRoot:     workspaceRoot,
+			TargetDir:         targetDir,
+			OzPath:            ozPath,
+			SetupCommand:      setupCmd,
+			TeardownCommand:   teardownCmd,
+			NoCleanup:         noCleanup,
+			Env:               mergedEnv,
+			HarnessConfigDirs: harnessConfigDirs,
 		}
 
 	case "command":


### PR DESCRIPTION
## Summary

Addresses REMOTE-2316: when a task runs with the Claude Code or Codex harness on a self-hosted direct backend, local plugins/skills on the host are not available because the worker isolates each task into an empty harness config directory.

## Changes

**New `harness_config_dirs` config option for the direct backend** — operators can point at a host directory to seed into each task's isolated harness config directory before the task runs:

```yaml
backend:
  direct:
    harness_config_dirs:
      claude: "/home/operator/.claude"
      codex:  "/home/operator/.codex"
```

The host directory is **copied** (not mounted), so each task gets an isolated snapshot and concurrent tasks don't interfere. Writes during a task are discarded on cleanup. If the source directory doesn't exist the step is silently skipped.

**README documentation** — a new "Claude Code harness: local plugins and settings" section documents:
- The `harness_config_dirs` feature for the direct backend
- Volume mount workaround for the Docker backend
- PVC and custom sidecar options for the Kubernetes backend
- Current state for Warp-managed cloud environments

## Files changed

- `internal/config/config.go` — `HarnessConfigDirs` field on `DirectConfig`
- `internal/worker/direct.go` — `HarnessConfigDirs` on `DirectBackendConfig`, `seedHarnessConfigDir()` implementation, call site in `ExecuteTask`
- `main.go` — wire `HarnessConfigDirs` from config to backend
- `internal/worker/direct_test.go` — 4 new test cases covering the seeding logic
- `README.md` — new section with per-backend workaround guidance

## Labels

from-feedback-bot

_Conversation: https://staging.warp.dev/conversation/3c455f9d-3d88-4000-8906-3aa7a8abe321_
_Run: https://oz.staging.warp.dev/runs/019f95f2-e472-737c-a531-c2542b8a5e0a_

_This PR was generated with [Oz](https://warp.dev/oz)._
