### PR TITLE
Improve Docker image pull error message for network connectivity failures (REMOTE-2322)

### DIFF
--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -2,8 +2,11 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"strings"
 	"time"
 
@@ -242,6 +245,32 @@ func (b *DockerBackend) PreservesTasksOnShutdown() bool {
 	return false
 }
 
+// isDockerNetworkError returns true when err is a network-level failure (dial,
+// timeout, connection refused) that suggests the Docker registry may be
+// unreachable. These errors are distinct from authentication failures or
+// missing images and typically indicate a network-connectivity or IP-allowlist
+// issue between the worker and Docker Hub (e.g. Docker Hub added a new egress
+// IP not yet allowlisted). See REMOTE-2322.
+func isDockerNetworkError(err error) bool {
+	var netErr *net.OpError
+	var urlErr *url.Error
+	switch {
+	case errors.As(err, &netErr):
+		return true
+	case errors.As(err, &urlErr):
+		// url.Error wraps net.OpError for dial/timeout errors.
+		return true
+	default:
+		// Fall back to string matching for errors surfaced as plain strings
+		// by the Docker client (e.g. "context deadline exceeded").
+		msg := err.Error()
+		return strings.Contains(msg, "connection refused") ||
+			strings.Contains(msg, "no such host") ||
+			strings.Contains(msg, "dial tcp") ||
+			strings.Contains(msg, "i/o timeout")
+	}
+}
+
 // pullImage pulls a Docker image. If authStr is non-empty, it will be used for registry authentication.
 // Docker only downloads changed layers, so this is efficient even if the image exists locally.
 func (b *DockerBackend) pullImage(ctx context.Context, imageName string, authStr string) error {
@@ -252,6 +281,14 @@ func (b *DockerBackend) pullImage(ctx context.Context, imageName string, authStr
 	}
 	reader, err := b.dockerClient.ImagePull(ctx, imageName, pullOptions)
 	if err != nil {
+		if isDockerNetworkError(err) {
+			return fmt.Errorf(
+				"failed to pull image %s: network connectivity error reaching Docker Hub — "+
+					"this may indicate that Docker Hub has added new egress IP addresses that "+
+					"are not yet allowlisted in this environment's network configuration: %w",
+				imageName, err,
+			)
+		}
 		return fmt.Errorf("failed to pull image %s: %w", imageName, err)
 	}
 	defer func() {


### PR DESCRIPTION
## Summary

Improves the error message emitted by oz-agent-worker when Docker image pull fails due to a network connectivity error, addressing REMOTE-2322 action item #3 (improve user-facing error messages when cloud runs fail due to network connectivity issues).

## Problem

Previously, when `ImagePull` failed with a network error, the logged message was a generic:
```
failed to pull image warpdotdev/dev-ubuntu:latest: dial tcp <ip>:443: i/o timeout
```

This gave no context about why the connection might be failing, making it harder to diagnose allowlist gaps.

## Change

Adds `isDockerNetworkError()` which recognizes `net.OpError`, `url.Error`, and string-based network error indicators (connection refused, dial tcp, etc.).

When a network error is detected during image pull, the error message now includes a hint:
```
failed to pull image warpdotdev/dev-ubuntu:latest: network connectivity error reaching Docker Hub —
this may indicate that Docker Hub has added new egress IP addresses that are not yet allowlisted
in this environment's network configuration: dial tcp <ip>:443: i/o timeout
```

Non-network failures (auth errors, missing images, rate limits) continue to produce the original simpler message.

## Testing

- `go build ./...` passes
- `go test ./internal/worker/...` passes (all existing tests continue to pass)

_Conversation: https://staging.warp.dev/conversation/ce430aa1-c96c-4c67-8312-e63b2d8bf3ec_
_Run: https://oz.staging.warp.dev/runs/019f95f3-a68d-70cf-9c37-1321a20d5b08_

_This PR was generated with [Oz](https://warp.dev/oz)._
