### PR TITLE
Emit --computer-use by default when computer_use_enabled is unset

### DIFF
--- a/internal/common/task_utils.go
+++ b/internal/common/task_utils.go
@@ -54,9 +54,14 @@ func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions
 			}
 		}
 
-		// Pass the computer use setting. Enabled by default; an explicit
-		// false disables it. Mirrors warp-server's IsComputerUseEnabled.
-		if task.AgentConfigSnapshot.ComputerUseEnabled == nil || *task.AgentConfigSnapshot.ComputerUseEnabled {
+		// Pass the computer use setting. An explicit value wins; when unset,
+		// computer use defaults to enabled for Oz-harness runs and disabled
+		// for third-party harnesses. Mirrors warp-server's IsComputerUseEnabled.
+		computerUseEnabled := task.AgentConfigSnapshot.Harness.IsOz()
+		if task.AgentConfigSnapshot.ComputerUseEnabled != nil {
+			computerUseEnabled = *task.AgentConfigSnapshot.ComputerUseEnabled
+		}
+		if computerUseEnabled {
 			args = append(args, "--computer-use")
 		} else {
 			args = append(args, "--no-computer-use")

--- a/internal/common/task_utils.go
+++ b/internal/common/task_utils.go
@@ -54,13 +54,12 @@ func AugmentArgsForTask(task *types.Task, args []string, opts TaskAugmentOptions
 			}
 		}
 
-		// Pass computer use setting if explicitly configured.
-		if task.AgentConfigSnapshot.ComputerUseEnabled != nil {
-			if *task.AgentConfigSnapshot.ComputerUseEnabled {
-				args = append(args, "--computer-use")
-			} else {
-				args = append(args, "--no-computer-use")
-			}
+		// Pass the computer use setting. Enabled by default; an explicit
+		// false disables it. Mirrors warp-server's IsComputerUseEnabled.
+		if task.AgentConfigSnapshot.ComputerUseEnabled == nil || *task.AgentConfigSnapshot.ComputerUseEnabled {
+			args = append(args, "--computer-use")
+		} else {
+			args = append(args, "--no-computer-use")
 		}
 
 		// Forward the AWS Bedrock OIDC role ARN, if any. When a region is also

--- a/internal/common/task_utils_test.go
+++ b/internal/common/task_utils_test.go
@@ -65,7 +65,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--computer-use", "--harness", "claude", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--no-computer-use", "--harness", "claude", "--idle-on-complete"},
 		},
 		{
 			name: "skips --harness when harness type is nil",
@@ -312,6 +312,27 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 			expected: []string{"agent", "run", "--no-computer-use", "--idle-on-complete"},
 		},
 		{
+			name: "adds --no-computer-use by default for a third-party harness",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					Harness: &types.Harness{Type: strPtr("codex")},
+				},
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--no-computer-use", "--harness", "codex", "--idle-on-complete"},
+		},
+		{
+			name: "adds --computer-use for a third-party harness when explicitly enabled",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					ComputerUseEnabled: boolPtr(true),
+					Harness:            &types.Harness{Type: strPtr("codex")},
+				},
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--computer-use", "--harness", "codex", "--idle-on-complete"},
+		},
+		{
 			// The top-level model_id targets the Oz harness. Third-party harnesses
 			// resolve their model from the task snapshot's harness config, so leaking
 			// the Oz model id via --model would cause them to reject the run.
@@ -323,7 +344,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--harness", "claude", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--no-computer-use", "--harness", "claude", "--idle-on-complete"},
 		},
 	}
 

--- a/internal/common/task_utils_test.go
+++ b/internal/common/task_utils_test.go
@@ -29,7 +29,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{IdleOnComplete: "30m"},
-			expected: []string{"agent", "run", "--idle-on-complete", "15m"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete", "15m"},
 		},
 		{
 			name: "falls back to worker idle_on_complete when task timeout not set",
@@ -37,7 +37,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
 			opts:     TaskAugmentOptions{IdleOnComplete: "30m"},
-			expected: []string{"agent", "run", "--idle-on-complete", "30m"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete", "30m"},
 		},
 		{
 			name: "uses oz cli default when neither task nor worker timeout is set",
@@ -45,7 +45,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
 		},
 		{
 			name: "ignores non-positive task idle_timeout_minutes and falls back to worker value",
@@ -55,7 +55,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{IdleOnComplete: "20m"},
-			expected: []string{"agent", "run", "--idle-on-complete", "20m"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete", "20m"},
 		},
 		{
 			name: "adds --harness when harness type is set",
@@ -65,7 +65,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--harness", "claude", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--harness", "claude", "--idle-on-complete"},
 		},
 		{
 			name: "skips --harness when harness type is nil",
@@ -75,7 +75,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
 		},
 		{
 			name: "still appends other config-derived args before idle timeout",
@@ -86,7 +86,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--model", "claude-sonnet-4", "--idle-on-complete", "12m"},
+			expected: []string{"agent", "run", "--model", "claude-sonnet-4", "--computer-use", "--idle-on-complete", "12m"},
 		},
 		{
 			name: "passes --bedrock-inference-role when inference_providers.aws.role_arn is set",
@@ -106,6 +106,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				"run",
 				"--model",
 				"claude-sonnet-4",
+				"--computer-use",
 				"--bedrock-inference-role",
 				"arn:aws:iam::123456789012:role/BedrockInference",
 				"--idle-on-complete",
@@ -127,6 +128,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 			expected: []string{
 				"agent",
 				"run",
+				"--computer-use",
 				"--bedrock-inference-role",
 				"arn:aws:iam::123456789012:role/BedrockInference",
 				"--bedrock-role-region",
@@ -150,6 +152,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 			expected: []string{
 				"agent",
 				"run",
+				"--computer-use",
 				"--bedrock-inference-role",
 				"arn:aws:iam::123456789012:role/BedrockInference",
 				"--idle-on-complete",
@@ -165,7 +168,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
 		},
 		{
 			name: "skips --bedrock-inference-role when aws block is opted out",
@@ -180,7 +183,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
 		},
 		{
 			name: "adds --share public:view when session_sharing.public_access is VIEWER",
@@ -192,7 +195,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--share", "public:view", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--share", "public:view", "--idle-on-complete"},
 		},
 		{
 			name: "adds --share public:edit when session_sharing.public_access is EDITOR",
@@ -204,7 +207,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--share", "public:edit", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--share", "public:edit", "--idle-on-complete"},
 		},
 		{
 			name: "skips --share public when session_sharing is absent",
@@ -212,7 +215,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
 		},
 		{
 			name: "does not forward --conversation even when AgentConversationID is set; the embedded warp CLI reads it off task metadata",
@@ -221,7 +224,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				AgentConversationID: strPtr("abc-123"),
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
 		},
 		{
 			name: "skips --share public when public_access is nil",
@@ -231,7 +234,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
 		},
 		{
 			name: "silently omits --share public for unsupported access levels (defensive: FULL rejected earlier)",
@@ -243,7 +246,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
 		},
 		{
 			name: "adds snapshot controls when configured",
@@ -257,6 +260,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 			opts: TaskAugmentOptions{},
 			expected: []string{
 				"agent", "run",
+				"--computer-use",
 				"--no-snapshot",
 				"--snapshot-upload-timeout", "90s",
 				"--snapshot-script-timeout", "45s",
@@ -269,7 +273,7 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
 			opts:     TaskAugmentOptions{AdditionalOzArgs: []string{"--skip-initial-turn"}},
-			expected: []string{"agent", "run", "--skip-initial-turn", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--skip-initial-turn", "--idle-on-complete"},
 		},
 		{
 			name: "does not emit supplemental oz args when none are provided",
@@ -277,7 +281,35 @@ func TestAugmentArgsForTask_IdleOnCompletePrecedence(t *testing.T) {
 				AgentConfigSnapshot: &types.AmbientAgentConfig{},
 			},
 			opts:     TaskAugmentOptions{},
-			expected: []string{"agent", "run", "--idle-on-complete"},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
+		},
+		{
+			name: "adds --computer-use by default when computer_use_enabled is unset",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{},
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
+		},
+		{
+			name: "adds --computer-use when computer_use_enabled is true",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					ComputerUseEnabled: boolPtr(true),
+				},
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--computer-use", "--idle-on-complete"},
+		},
+		{
+			name: "adds --no-computer-use when computer_use_enabled is false",
+			task: &types.Task{
+				AgentConfigSnapshot: &types.AmbientAgentConfig{
+					ComputerUseEnabled: boolPtr(false),
+				},
+			},
+			opts:     TaskAugmentOptions{},
+			expected: []string{"agent", "run", "--no-computer-use", "--idle-on-complete"},
 		},
 		{
 			// The top-level model_id targets the Oz harness. Third-party harnesses


### PR DESCRIPTION
## Summary
Companion to warpdotdev/warp-server#13465 (computer use no longer experimental, enabled by default for Oz-harness runs).

The worker now always emits a computer-use flag when building oz CLI args from the agent config snapshot, mirroring warp-server's `IsComputerUseEnabled`: an explicit `computer_use_enabled` value wins; when unset, runs on Warp's built-in harness get `--computer-use` and third-party harness runs (Claude Code, Gemini, Codex) get `--no-computer-use`, since those harnesses don't integrate with Warp's computer-use tooling. Previously, unset configs emitted no flag, leaving the CLI's own default in charge — which meant a self-hosted run with an unset config could get the Xvfb sidecar mounted (server decision) without the agent actually enabling computer use.

## Rollout
Safe in either order relative to the server PR: a new worker with an old server just makes the current dogfood-default behavior explicit, and an old worker with the new server degrades to today's behavior.

## Validation
- Updated `TestAugmentArgsForTask` expectations and added unset/true/false subtests, including third-party-harness default and explicit-enable cases.
- Verified end-to-end on the local Oz stack: an API run omitting `computer_use_enabled` now spawns the agent with `--computer-use`; explicit false yields `--no-computer-use`.

[Conversation](https://staging.warp.dev/conversation/4c268425-a4c3-44c7-bb8c-619055cc6eae)

Co-Authored-By: Oz <oz-agent@warp.dev>