### PR TITLE
Add opt-in Helm support for the command backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,5 @@ jobs:
       - uses: azure/setup-helm@v4
         with:
           version: v4.1.3
-      - name: Lint Helm chart
-        run: helm lint ./charts/oz-agent-worker --set worker.workerId=ci-worker --set image.tag=ci
-      - name: Render Helm chart
-        run: helm template oz-agent-worker ./charts/oz-agent-worker --namespace agents --set worker.workerId=ci-worker --set image.tag=ci >/tmp/oz-agent-worker-chart.yaml
+      - name: Test Helm chart
+        run: ./charts/oz-agent-worker/ci/test-chart.sh

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ The dispatch contract:
 Because dispatched tasks run independently of the worker process, the command backend does not consume a local concurrency slot for the lifetime of the remote task, and worker shutdown does not cancel already-dispatched tasks.
 The runtime *must* report completion by executing `oz harness-support report-shutdown` using the provided run ID.
 
+To host the worker in Kubernetes, see [Command backend with Helm](#command-backend-with-helm).
+
+Reference scripts are available in [`examples/command-backend`](./examples/command-backend).
+
 ### Kubernetes
 
 The Kubernetes backend creates one Job per task. Cluster selection is controlled by the Kubernetes client config:
@@ -186,6 +190,44 @@ pod_template:
               key: secret-key
 ```
 
+#### Command backend with Helm
+
+The worker can run in Kubernetes while dispatching tasks through the command backend instead of creating task Jobs. Opt in with `backend.type=command`. `commandBackend.dispatchCommand` is required; `cancelCommand`, `dispatchTimeout`, and `environment` are optional.
+
+Add scripts through an existing ConfigMap and credentials through a Secret. The example below uses the reference [`dispatch.py` and `cancel.py` scripts](./examples/command-backend). These scripts require Python, which is not included in the standard worker image, so replace the image with one that includes Python to run the example. Use an image with the appropriate tools for your own scripts.
+
+Create the script ConfigMap:
+
+```bash
+kubectl create configmap oz-dispatch \
+  --from-file=dispatch.py=examples/command-backend/dispatch.py \
+  --from-file=cancel.py=examples/command-backend/cancel.py
+```
+
+Then configure the chart and mounted scripts:
+
+```yaml
+backend:
+  type: command
+commandBackend:
+  dispatchCommand: "python3 /opt/oz/dispatch.py"
+  cancelCommand: "python3 /opt/oz/cancel.py"
+image:
+  repository: warpdotdev/oz-agent-worker
+  tag: v2026-08-04-15-14-28
+worker:
+  workerId: my-worker
+  extraVolumes:
+    - name: dispatch-scripts
+      configMap:
+        name: oz-dispatch
+  extraVolumeMounts:
+    - name: dispatch-scripts
+      mountPath: /opt/oz
+      readOnly: true
+```
+
+The standard image above is the base only. Build a custom image from it that includes the language runtime for your scripts, then set `image.repository` / `image.tag` to that image. For example, to run Python scripts, add Python to the image.
 
 ### Helm Chart
 

--- a/README.md
+++ b/README.md
@@ -196,15 +196,21 @@ The worker can run in Kubernetes while dispatching tasks through the command bac
 
 Add scripts through an existing ConfigMap and credentials through a Secret. The example below uses the reference [`dispatch.py` and `cancel.py` scripts](./examples/command-backend). These scripts require Python, which is not included in the standard worker image, so replace the image with one that includes Python to run the example. Use an image with the appropriate tools for your own scripts.
 
-Create the script ConfigMap:
+Create the release namespace before creating namespaced resources, then create the script ConfigMap and dispatch credential:
 
 ```bash
+kubectl create namespace agents --dry-run=client -o yaml | kubectl apply -f -
 kubectl create configmap oz-dispatch \
   --from-file=dispatch.py=examples/command-backend/dispatch.py \
-  --from-file=cancel.py=examples/command-backend/cancel.py
+  --from-file=cancel.py=examples/command-backend/cancel.py \
+  --namespace agents
+
+kubectl create secret generic oz-dispatch-credentials \
+  --from-literal=OZ_DISPATCH_AUTH_HEADER='<replace-with-credential>' \
+  --namespace agents
 ```
 
-Then configure the chart and mounted scripts:
+Then configure the chart, mounted scripts, and Secret-backed worker environment:
 
 ```yaml
 backend:
@@ -212,11 +218,19 @@ backend:
 commandBackend:
   dispatchCommand: "python3 /opt/oz/dispatch.py"
   cancelCommand: "python3 /opt/oz/cancel.py"
+  environment:
+    - name: OZ_DISPATCH_AUTH_HEADER
 image:
-  repository: warpdotdev/oz-agent-worker
-  tag: v2026-08-04-15-14-28
+  repository: example.registry.internal/oz-agent-worker-python
+  tag: <version>
 worker:
   workerId: my-worker
+  extraEnv:
+    - name: OZ_DISPATCH_AUTH_HEADER
+      valueFrom:
+        secretKeyRef:
+          name: oz-dispatch-credentials
+          key: OZ_DISPATCH_AUTH_HEADER
   extraVolumes:
     - name: dispatch-scripts
       configMap:
@@ -227,7 +241,9 @@ worker:
       readOnly: true
 ```
 
-The standard image above is the base only. Build a custom image from it that includes the language runtime for your scripts, then set `image.repository` / `image.tag` to that image. For example, to run Python scripts, add Python to the image.
+The custom image placeholder above must be replaced with an image that contains both `oz-agent-worker` and Python. The `worker.extraEnv` entry loads the credential from the Kubernetes Secret into the worker Pod, and the matching `commandBackend.environment` entry omits `value` so the dispatch and cancel commands inherit it.
+
+> **Warning:** Literal `commandBackend.environment[].value` entries are rendered into the chart's worker `ConfigMap`. Do not put credentials there. Use `worker.extraEnv[].valueFrom.secretKeyRef` as above, or mount a Secret read-only with `worker.extraVolumes` / `worker.extraVolumeMounts`.
 
 ### Helm Chart
 
@@ -237,15 +253,16 @@ The chart deploys:
 
 - a long-lived `Deployment` for `oz-agent-worker`
 - a namespaced `ServiceAccount`
-- a namespaced `Role` / `RoleBinding`
+- a namespaced `Role` / `RoleBinding` for the Kubernetes backend
 - a `ConfigMap` containing the worker config
 - an optional `Secret` for `WARP_API_KEY` (or a reference to an existing `Secret`)
 
-At runtime, the deployed worker connects outbound to Warp and creates one Kubernetes `Job` per task. The built-in Kubernetes Job controller then manages the task Pod lifecycle.
+At runtime, the deployed worker connects outbound to Warp. The default Kubernetes backend creates one Kubernetes `Job` per task, and the built-in Kubernetes Job controller manages the task Pod lifecycle. Command mode does not create task Jobs or their Role/RoleBinding; it invokes the operator-provided dispatcher mounted in the worker Pod.
 
 Recommended install flow:
 
 ```bash
+kubectl create namespace agents --dry-run=client -o yaml | kubectl apply -f -
 kubectl create secret generic oz-agent-worker \
   --from-literal=WARP_API_KEY="wk-abc123" \
   --namespace agents

--- a/charts/oz-agent-worker/ci/command-values.yaml
+++ b/charts/oz-agent-worker/ci/command-values.yaml
@@ -1,0 +1,32 @@
+backend:
+  type: command
+
+commandBackend:
+  dispatchCommand: python3 /opt/oz/dispatch.py
+  cancelCommand: python3 /opt/oz/cancel.py
+  dispatchTimeout: 45s
+  environment:
+    - name: OZ_DISPATCH_URL
+      value: https://runtime.example.test/dispatch
+    - name: OZ_DISPATCH_AUTH_HEADER
+
+image:
+  repository: example.registry.internal/oz-agent-worker-python
+  tag: ci
+
+worker:
+  workerId: ci-command-worker
+  extraEnv:
+    - name: OZ_DISPATCH_AUTH_HEADER
+      valueFrom:
+        secretKeyRef:
+          name: oz-dispatch-credentials
+          key: OZ_DISPATCH_AUTH_HEADER
+  extraVolumes:
+    - name: dispatch-scripts
+      configMap:
+        name: oz-dispatch
+  extraVolumeMounts:
+    - name: dispatch-scripts
+      mountPath: /opt/oz
+      readOnly: true

--- a/charts/oz-agent-worker/ci/test-chart.sh
+++ b/charts/oz-agent-worker/ci/test-chart.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHART_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMMAND_VALUES="$SCRIPT_DIR/command-values.yaml"
+OUTPUT_DIR="$(mktemp -d)"
+trap 'rm -rf "$OUTPUT_DIR"' EXIT
+
+fail() {
+  printf 'helm chart test failed: %s\n' "$*" >&2
+  exit 1
+}
+
+assert_contains() {
+  local file="$1"
+  local text="$2"
+  grep -Fq -- "$text" "$file" ||
+    fail "expected $(basename "$file") to contain: $text"
+}
+
+assert_matches() {
+  local file="$1"
+  local pattern="$2"
+  grep -Eq -- "$pattern" "$file" ||
+    fail "expected $(basename "$file") to match: $pattern"
+}
+
+assert_not_matches() {
+  local file="$1"
+  local pattern="$2"
+  if grep -Eq -- "$pattern" "$file"; then
+    fail "expected $(basename "$file") not to match: $pattern"
+  fi
+}
+
+DEFAULT_RENDER="$OUTPUT_DIR/default.yaml"
+COMMAND_RENDER="$OUTPUT_DIR/command.yaml"
+
+helm lint "$CHART_DIR" \
+  --set worker.workerId=ci-kubernetes-worker \
+  --set image.tag=ci
+helm template oz-agent-worker "$CHART_DIR" \
+  --namespace agents \
+  --set worker.workerId=ci-kubernetes-worker \
+  --set image.tag=ci >"$DEFAULT_RENDER"
+
+helm lint "$CHART_DIR" --values "$COMMAND_VALUES"
+helm template oz-agent-worker "$CHART_DIR" \
+  --namespace agents \
+  --values "$COMMAND_VALUES" >"$COMMAND_RENDER"
+
+# The default remains Kubernetes-compatible and retains task Job RBAC.
+assert_contains "$DEFAULT_RENDER" "- --backend"
+assert_contains "$DEFAULT_RENDER" "- kubernetes"
+assert_matches "$DEFAULT_RENDER" '^kind: Role$'
+assert_matches "$DEFAULT_RENDER" '^kind: RoleBinding$'
+
+# Command mode renders its config, worker args, script mount, and Secret-backed env.
+assert_contains "$COMMAND_RENDER" 'dispatch_command: "python3 /opt/oz/dispatch.py"'
+assert_contains "$COMMAND_RENDER" 'cancel_command: "python3 /opt/oz/cancel.py"'
+assert_contains "$COMMAND_RENDER" 'dispatch_timeout: "45s"'
+assert_contains "$COMMAND_RENDER" "- --backend"
+assert_contains "$COMMAND_RENDER" "- command"
+assert_contains "$COMMAND_RENDER" "mountPath: /opt/oz"
+assert_contains "$COMMAND_RENDER" "name: dispatch-scripts"
+assert_contains "$COMMAND_RENDER" "name: oz-dispatch"
+assert_contains "$COMMAND_RENDER" "name: OZ_DISPATCH_AUTH_HEADER"
+assert_contains "$COMMAND_RENDER" "secretKeyRef:"
+assert_contains "$COMMAND_RENDER" "name: oz-dispatch-credentials"
+assert_contains "$COMMAND_RENDER" "key: OZ_DISPATCH_AUTH_HEADER"
+assert_not_matches "$COMMAND_RENDER" '^kind: Role$'
+assert_not_matches "$COMMAND_RENDER" '^kind: RoleBinding$'
+
+if helm template oz-agent-worker "$CHART_DIR" \
+  --namespace agents \
+  --set worker.workerId=ci-worker \
+  --set image.tag=ci \
+  --set backend.type=invalid >"$OUTPUT_DIR/invalid.yaml" 2>"$OUTPUT_DIR/invalid.err"; then
+  fail "invalid backend.type rendered successfully"
+fi
+assert_contains "$OUTPUT_DIR/invalid.err" 'backend.type must be "kubernetes" or "command"'
+
+if helm template oz-agent-worker "$CHART_DIR" \
+  --namespace agents \
+  --set worker.workerId=ci-worker \
+  --set image.tag=ci \
+  --set backend.type=command >"$OUTPUT_DIR/missing-dispatch.yaml" 2>"$OUTPUT_DIR/missing-dispatch.err"; then
+  fail "command backend without commandBackend.dispatchCommand rendered successfully"
+fi
+assert_contains "$OUTPUT_DIR/missing-dispatch.err" "commandBackend.dispatchCommand is required when backend.type=command"
+
+printf 'helm chart tests passed\n'

--- a/charts/oz-agent-worker/templates/_helpers.tpl
+++ b/charts/oz-agent-worker/templates/_helpers.tpl
@@ -48,3 +48,15 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- required "warp.apiKeySecret.name is required when warp.apiKeySecret.create=false" .Values.warp.apiKeySecret.name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Resolve and validate the worker execution backend.
+Supported: kubernetes (default), command.
+*/}}
+{{- define "oz-agent-worker.backendType" -}}
+{{- $type := default "kubernetes" .Values.backend.type -}}
+{{- if not (or (eq $type "kubernetes") (eq $type "command")) -}}
+{{- fail (printf "backend.type must be \"kubernetes\" or \"command\", got %q" $type) -}}
+{{- end -}}
+{{- $type -}}
+{{- end -}}

--- a/charts/oz-agent-worker/templates/configmap.yaml
+++ b/charts/oz-agent-worker/templates/configmap.yaml
@@ -14,6 +14,21 @@ data:
     idle_on_complete: {{ .Values.worker.idleOnComplete | quote }}
     {{- end }}
     backend:
+      {{- $backendType := include "oz-agent-worker.backendType" . }}
+      {{- if eq $backendType "command" }}
+      command:
+        dispatch_command: {{ required "commandBackend.dispatchCommand is required when backend.type=command" .Values.commandBackend.dispatchCommand | quote }}
+        {{- if .Values.commandBackend.cancelCommand }}
+        cancel_command: {{ .Values.commandBackend.cancelCommand | quote }}
+        {{- end }}
+        {{- if .Values.commandBackend.dispatchTimeout }}
+        dispatch_timeout: {{ .Values.commandBackend.dispatchTimeout | quote }}
+        {{- end }}
+        {{- with .Values.commandBackend.environment }}
+        environment:
+{{ toYaml . | indent 10 }}
+        {{- end }}
+      {{- else }}
       kubernetes:
         namespace: {{ default .Release.Namespace .Values.kubernetesBackend.namespace | quote }}
         {{- if .Values.kubernetesBackend.defaultImage }}
@@ -61,3 +76,4 @@ data:
         preflight_resources:
 {{ toYaml .Values.kubernetesBackend.preflightResources | indent 10 }}
         {{- end }}
+      {{- end }}

--- a/charts/oz-agent-worker/templates/deployment.yaml
+++ b/charts/oz-agent-worker/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
             - --config-file
             - /etc/oz-agent-worker/config.yaml
             - --backend
-            - kubernetes
+            - {{ include "oz-agent-worker.backendType" . }}
             - --log-level
             - {{ .Values.worker.logLevel | quote }}
             - --web-socket-url
@@ -98,6 +98,9 @@ spec:
             - name: config
               mountPath: /etc/oz-agent-worker
               readOnly: true
+            {{- with .Values.worker.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           {{- with .Values.worker.livenessProbe }}
           livenessProbe:
             {{- toYaml . | nindent 12 }}
@@ -114,6 +117,9 @@ spec:
         - name: config
           configMap:
             name: {{ include "oz-agent-worker.fullname" . }}-config
+        {{- with .Values.worker.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       {{- with .Values.worker.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/oz-agent-worker/templates/role.yaml
+++ b/charts/oz-agent-worker/templates/role.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.rbac.create }}
+{{- /* Task Job/Pod RBAC is only needed for the kubernetes backend. */ -}}
+{{- if and .Values.rbac.create (eq (include "oz-agent-worker.backendType" .) "kubernetes") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/oz-agent-worker/templates/rolebinding.yaml
+++ b/charts/oz-agent-worker/templates/rolebinding.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.rbac.create }}
+{{- /* Bind task Job/Pod Role only when the kubernetes backend is selected. */ -}}
+{{- if and .Values.rbac.create (eq (include "oz-agent-worker.backendType" .) "kubernetes") }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/oz-agent-worker/values.yaml
+++ b/charts/oz-agent-worker/values.yaml
@@ -35,6 +35,11 @@ worker:
   idleOnComplete: ""
   extraArgs: []
   extraEnv: []
+  # Additional volumes and mounts on the long-lived worker pod. Use these to
+  # attach ConfigMaps or Secrets containing dispatch scripts, SSH keys, or
+  # other required files. The chart does not create those resources.
+  extraVolumes: []
+  extraVolumeMounts: []
   deploymentAnnotations: {}
   podAnnotations: {}
   podLabels: {}
@@ -70,6 +75,24 @@ worker:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+
+# Execution backend for tasks claimed by this worker.
+# - kubernetes (default): create one Kubernetes Job per task.
+# - command: invoke a customer-provided dispatch command using HTTPS, gRPC,
+#   SSH, or similar.
+backend:
+  type: kubernetes
+# Used only when backend.type=command. Provide scripts/tools via image overrides and/or
+# worker.extraVolumes / worker.extraVolumeMounts.
+commandBackend:
+  # Required when backend.type=command. Shell command run via /bin/sh -c;
+  # receives the task DispatchPayload as JSON on stdin.
+  dispatchCommand: ""
+  # Optional cancel command.
+  cancelCommand: ""
+  dispatchTimeout: "60s"
+  # Environment variables for dispatch and cancel commands.
+  environment: []
 
 kubernetesBackend:
   namespace: ""

--- a/charts/oz-agent-worker/values.yaml
+++ b/charts/oz-agent-worker/values.yaml
@@ -91,7 +91,11 @@ commandBackend:
   # Optional cancel command.
   cancelCommand: ""
   dispatchTimeout: "60s"
-  # Environment variables for dispatch and cancel commands.
+  # Environment variables for dispatch and cancel commands. Literal `value`
+  # fields are rendered into the chart ConfigMap and must not contain
+  # credentials. Load secrets into the worker Pod with
+  # worker.extraEnv[].valueFrom.secretKeyRef (or a read-only Secret volume),
+  # then omit `value` here to inherit them.
   environment: []
 
 kubernetesBackend:


### PR DESCRIPTION
## Summary
- Adds an opt-in `backend.type=command` path to the Helm chart so the worker can run in Kubernetes and dispatch via a mounted script instead of creating task Jobs.
- Keeps the default chart path on the existing Kubernetes task Job architecture (`backend.type=kubernetes`).
- Documents mounting dispatch/cancel scripts via ConfigMap/Secret volumes, including that script runtimes (e.g. Python) must be added to a custom image.
- Note: our example script uses Python which isn't installed in the default image so need to nudge people if they want to use this method, they need to extend the image to support whatever scripts they load on.

## Test plan
- [x] `helm lint` with default values and command-backend values
- [x] Default rendered manifests match pre-change chart output byte-for-byte for the same values
- [x] Command mode renders `backend.command`, mounts, and omits task Job/Pod Role/RoleBinding
- [x] Live GKE default backend: isolated release created task Job and completed a real Oz run
- [x] Live GKE command backend: ConfigMap-mounted script received dispatch payload; no task Jobs/RBAC
- [x] README example values render successfully

Co-Authored-By: Warp Agent <agent@warp.dev>