### PR TITLE
feat(worker): report container setup phase durations as run client events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/distribution/reference v0.6.0
 	github.com/docker/cli v29.3.1+incompatible
 	github.com/go-playground/validator/v10 v10.30.1
+	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.4-0.20250319132907-e064f32e3674
 	github.com/joho/godotenv v1.5.1
 	github.com/moby/moby/api v1.54.2
@@ -50,7 +51,6 @@ require (
 	github.com/go-playground/locales v0.14.1 // indirect
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/internal/worker/backend.go
+++ b/internal/worker/backend.go
@@ -85,6 +85,10 @@ type TaskParams struct {
 	// Containerized backends apply it as CPU/memory limits (Docker) or resource
 	// requests/limits (Kubernetes). Backends that cannot enforce a shape (direct) ignore it.
 	InstanceShape *types.InstanceShape
+
+	// SetupEvents reports worker-observed setup phase durations to warp-server.
+	// It may be nil, and all of its methods are safe to call on a nil reporter.
+	SetupEvents *setupEventReporter
 }
 
 // Backend defines the interface for task execution backends.

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -103,21 +103,24 @@ func (b *DockerBackend) ExecuteTask(ctx context.Context, params *TaskParams) Exe
 	log.Debugf(ctx, "Using Docker image: %s", imageName)
 
 	authStr := b.getRegistryAuth(ctx, imageName)
-	pullStart := time.Now()
+	doneImagePull := params.SetupEvents.startPhase(ctx, SetupEventImagePull)
 	if err := b.pullImage(ctx, imageName, authStr); err != nil {
-		params.SetupEvents.reportPhase(ctx, SetupEventImagePull, pullStart, time.Now(), true)
+		doneImagePull(true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonImagePull, err))
 	}
-	params.SetupEvents.reportPhase(ctx, SetupEventImagePull, pullStart, time.Now(), false)
+	doneImagePull(false)
 
 	// Prepare all sidecar volumes (Warp agent sidecar + any additional sidecars).
-	sidecarPrepStart := time.Now()
+	// Report the phase only when the task has sidecars, matching the Kubernetes
+	// backend; zero-sidecar tasks would otherwise emit ~0ms samples that skew
+	// the phase percentiles.
+	doneSidecarPrep := params.SetupEvents.startPhaseIf(ctx, SetupEventSidecarPrep, len(params.Sidecars) > 0)
 	sidecarBinds, err := b.prepareSidecars(ctx, dockerClient, params.Sidecars)
 	if err != nil {
-		params.SetupEvents.reportPhase(ctx, SetupEventSidecarPrep, sidecarPrepStart, time.Now(), true)
+		doneSidecarPrep(true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonSidecarPrep, err))
 	}
-	params.SetupEvents.reportPhase(ctx, SetupEventSidecarPrep, sidecarPrepStart, time.Now(), false)
+	doneSidecarPrep(false)
 
 	// Start with common env vars, then append backend-specific config env vars.
 	envVars := make([]string, len(params.EnvVars))
@@ -147,13 +150,13 @@ func (b *DockerBackend) ExecuteTask(ctx context.Context, params *TaskParams) Exe
 		Resources: dockerResourcesForShape(params.InstanceShape),
 	}
 
-	containerStartBegin := time.Now()
+	doneContainerStart := params.SetupEvents.startPhase(ctx, SetupEventContainerStart)
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config:     containerConfig,
 		HostConfig: hostConfig,
 	})
 	if err != nil {
-		params.SetupEvents.reportPhase(ctx, SetupEventContainerStart, containerStartBegin, time.Now(), true)
+		doneContainerStart(true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonContainerCreate, fmt.Errorf("failed to create container: %w", err)))
 	}
 
@@ -171,10 +174,10 @@ func (b *DockerBackend) ExecuteTask(ctx context.Context, params *TaskParams) Exe
 	}()
 
 	if _, err := dockerClient.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
-		params.SetupEvents.reportPhase(ctx, SetupEventContainerStart, containerStartBegin, time.Now(), true)
+		doneContainerStart(true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonContainerStart, fmt.Errorf("failed to start container: %w", err)))
 	}
-	params.SetupEvents.reportPhase(ctx, SetupEventContainerStart, containerStartBegin, time.Now(), false)
+	doneContainerStart(false)
 
 	log.Debugf(ctx, "Started Docker container: %s", containerID)
 

--- a/internal/worker/docker.go
+++ b/internal/worker/docker.go
@@ -103,15 +103,21 @@ func (b *DockerBackend) ExecuteTask(ctx context.Context, params *TaskParams) Exe
 	log.Debugf(ctx, "Using Docker image: %s", imageName)
 
 	authStr := b.getRegistryAuth(ctx, imageName)
+	pullStart := time.Now()
 	if err := b.pullImage(ctx, imageName, authStr); err != nil {
+		params.SetupEvents.reportPhase(ctx, SetupEventImagePull, pullStart, time.Now(), true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonImagePull, err))
 	}
+	params.SetupEvents.reportPhase(ctx, SetupEventImagePull, pullStart, time.Now(), false)
 
 	// Prepare all sidecar volumes (Warp agent sidecar + any additional sidecars).
+	sidecarPrepStart := time.Now()
 	sidecarBinds, err := b.prepareSidecars(ctx, dockerClient, params.Sidecars)
 	if err != nil {
+		params.SetupEvents.reportPhase(ctx, SetupEventSidecarPrep, sidecarPrepStart, time.Now(), true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonSidecarPrep, err))
 	}
+	params.SetupEvents.reportPhase(ctx, SetupEventSidecarPrep, sidecarPrepStart, time.Now(), false)
 
 	// Start with common env vars, then append backend-specific config env vars.
 	envVars := make([]string, len(params.EnvVars))
@@ -141,11 +147,13 @@ func (b *DockerBackend) ExecuteTask(ctx context.Context, params *TaskParams) Exe
 		Resources: dockerResourcesForShape(params.InstanceShape),
 	}
 
+	containerStartBegin := time.Now()
 	resp, err := dockerClient.ContainerCreate(ctx, client.ContainerCreateOptions{
 		Config:     containerConfig,
 		HostConfig: hostConfig,
 	})
 	if err != nil {
+		params.SetupEvents.reportPhase(ctx, SetupEventContainerStart, containerStartBegin, time.Now(), true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonContainerCreate, fmt.Errorf("failed to create container: %w", err)))
 	}
 
@@ -163,8 +171,10 @@ func (b *DockerBackend) ExecuteTask(ctx context.Context, params *TaskParams) Exe
 	}()
 
 	if _, err := dockerClient.ContainerStart(ctx, containerID, client.ContainerStartOptions{}); err != nil {
+		params.SetupEvents.reportPhase(ctx, SetupEventContainerStart, containerStartBegin, time.Now(), true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonContainerStart, fmt.Errorf("failed to start container: %w", err)))
 	}
+	params.SetupEvents.reportPhase(ctx, SetupEventContainerStart, containerStartBegin, time.Now(), false)
 
 	log.Debugf(ctx, "Started Docker container: %s", containerID)
 

--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -45,6 +45,14 @@ const (
 	kubernetesExecutionIDLabel       = "oz-execution-id"
 	kubernetesExecutionHashLabel     = "oz-execution-hash"
 
+	// Task pod container names. kubernetesSetupPhaseTracker keys its phase
+	// reporting on these, so both the pod-spec construction below and the
+	// tracker must use these constants: a rename in one place would silently
+	// break phase reporting in the other.
+	kubernetesTaskContainerName  = "task"
+	kubernetesSetupContainerName = "setup"
+	kubernetesSidecarInitPrefix  = "copy-sidecar-"
+
 	// maxLogBytes caps the amount of container log data read into memory per
 	// container to avoid OOM when a task produces excessive output.
 	maxLogBytes = 1 << 20 // 1 MiB
@@ -208,7 +216,7 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 			},
 		})
 		initContainers = append(initContainers, corev1.Container{
-			Name:            fmt.Sprintf("copy-sidecar-%d", i),
+			Name:            fmt.Sprintf("%s%d", kubernetesSidecarInitPrefix, i),
 			Image:           sidecar.Image,
 			ImagePullPolicy: pullPolicy,
 			Command: []string{
@@ -240,7 +248,7 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 	if b.config.SetupCommand != "" {
 		setupEnv := envStringsToKubernetesEnv(mainEnv)
 		initContainers = append(initContainers, corev1.Container{
-			Name:            "setup",
+			Name:            kubernetesSetupContainerName,
 			Image:           params.DockerImage,
 			ImagePullPolicy: pullPolicy,
 			Command:         []string{"/bin/sh", "-c", b.config.SetupCommand},
@@ -252,7 +260,7 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 
 	mainEnvVars := envStringsToKubernetesEnv(mainEnv)
 	mainContainer := corev1.Container{
-		Name:            "task",
+		Name:            kubernetesTaskContainerName,
 		Image:           params.DockerImage,
 		ImagePullPolicy: pullPolicy,
 		Command: []string{
@@ -306,12 +314,12 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 	}
 
 	log.Infof(ctx, "Creating Kubernetes Job %s in namespace %s", jobName, b.config.Namespace)
-	jobCreateStart := time.Now()
+	doneJobCreate := params.SetupEvents.startPhase(ctx, SetupEventJobCreate)
 	if _, err := b.clientset.BatchV1().Jobs(b.config.Namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {
-		params.SetupEvents.reportPhase(ctx, SetupEventJobCreate, jobCreateStart, time.Now(), true)
+		doneJobCreate(true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonJobCreate, fmt.Errorf("failed to create Kubernetes Job: %w", err)))
 	}
-	params.SetupEvents.reportPhase(ctx, SetupEventJobCreate, jobCreateStart, time.Now(), false)
+	doneJobCreate(false)
 
 	// Derive the remaining setup phases (scheduling, sidecar prep, setup
 	// command, task container start) from pod status snapshots delivered by
@@ -562,7 +570,7 @@ func (b *KubernetesBackend) buildTaskPodSpec(initContainers []corev1.Container, 
 
 	taskIdx := -1
 	for i, c := range podSpec.Containers {
-		if c.Name == "task" {
+		if c.Name == kubernetesTaskContainerName {
 			taskIdx = i
 			break
 		}

--- a/internal/worker/kubernetes.go
+++ b/internal/worker/kubernetes.go
@@ -306,9 +306,17 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 	}
 
 	log.Infof(ctx, "Creating Kubernetes Job %s in namespace %s", jobName, b.config.Namespace)
+	jobCreateStart := time.Now()
 	if _, err := b.clientset.BatchV1().Jobs(b.config.Namespace).Create(ctx, job, metav1.CreateOptions{}); err != nil {
+		params.SetupEvents.reportPhase(ctx, SetupEventJobCreate, jobCreateStart, time.Now(), true)
 		return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonJobCreate, fmt.Errorf("failed to create Kubernetes Job: %w", err)))
 	}
+	params.SetupEvents.reportPhase(ctx, SetupEventJobCreate, jobCreateStart, time.Now(), false)
+
+	// Derive the remaining setup phases (scheduling, sidecar prep, setup
+	// command, task container start) from pod status snapshots delivered by
+	// the pod watch and the safety poll below.
+	setupPhases := newKubernetesSetupPhaseTracker(params.SetupEvents)
 
 	defer func() {
 		if ctx.Err() != nil {
@@ -402,6 +410,7 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 			if !ok {
 				continue
 			}
+			setupPhases.observePod(ctx, pod)
 			if failure := b.inspectPodFailure(ctx, pod); failure != nil {
 				logs := b.collectPodLogs(ctx, []corev1.Pod{*pod})
 				if logs != "" {
@@ -426,6 +435,9 @@ func (b *KubernetesBackend) ExecuteTask(ctx context.Context, params *TaskParams)
 			pods, err := b.listTaskPods(ctx, executionID)
 			if err != nil {
 				return executeError(newBackendFailure(metrics.TaskFailurePhaseBackend, metrics.TaskFailureReasonPodWatch, fmt.Errorf("failed to list task pods for Job %s: %w", jobName, err)))
+			}
+			for i := range pods {
+				setupPhases.observePod(ctx, &pods[i])
 			}
 			if failure := b.detectPodFailure(ctx, pods); failure != nil {
 				return executeError(failure)

--- a/internal/worker/kubernetes_setup_events.go
+++ b/internal/worker/kubernetes_setup_events.go
@@ -1,0 +1,170 @@
+package worker
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+)
+
+const (
+	kubernetesTaskContainerName  = "task"
+	kubernetesSetupContainerName = "setup"
+	kubernetesSidecarInitPrefix  = "copy-sidecar-"
+)
+
+// kubernetesSetupPhaseTracker derives task setup phase durations from pod
+// status snapshots and reports each phase once. The kubelet performs the
+// image pulls and container starts for this backend, so the worker cannot
+// time them directly; instead, every phase is computed from timestamps the
+// pod object carries (creation time, the PodScheduled condition transition,
+// init container terminations, and the task container start). Late or
+// repeated watch deliveries therefore do not skew the measurements.
+type kubernetesSetupPhaseTracker struct {
+	reporter *setupEventReporter
+	reported map[string]bool
+}
+
+func newKubernetesSetupPhaseTracker(reporter *setupEventReporter) *kubernetesSetupPhaseTracker {
+	return &kubernetesSetupPhaseTracker{
+		reporter: reporter,
+		reported: make(map[string]bool),
+	}
+}
+
+// observePod inspects a pod status snapshot and reports any newly completed
+// setup phases. It is safe to call repeatedly with successive snapshots and
+// is a no-op when reporting is disabled.
+func (t *kubernetesSetupPhaseTracker) observePod(ctx context.Context, pod *corev1.Pod) {
+	if t == nil || t.reporter == nil || pod == nil {
+		return
+	}
+	t.observeSchedule(ctx, pod)
+	t.observeSidecarPrep(ctx, pod)
+	t.observeSetupCommand(ctx, pod)
+	t.observeTaskStart(ctx, pod)
+}
+
+// report sends one phase at most once, skipping ranges the pod timestamps
+// cannot support (zero or inverted times).
+func (t *kubernetesSetupPhaseTracker) report(ctx context.Context, eventName string, start, finish time.Time, isError bool) {
+	if t.reported[eventName] || start.IsZero() || finish.IsZero() || finish.Before(start) {
+		return
+	}
+	t.reported[eventName] = true
+	t.reporter.reportPhase(ctx, eventName, start, finish, isError)
+}
+
+// observeSchedule reports the span from pod creation to a true PodScheduled
+// condition. This surfaces node capacity and autoscaler waits.
+func (t *kubernetesSetupPhaseTracker) observeSchedule(ctx context.Context, pod *corev1.Pod) {
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionTrue {
+			t.report(ctx, SetupEventPodSchedule, pod.CreationTimestamp.Time, condition.LastTransitionTime.Time, false)
+			return
+		}
+	}
+}
+
+// observeSidecarPrep reports one aggregate phase spanning the sequential
+// copy-sidecar-* init containers, from the first start to the last finish.
+// The kubelet's pull of each sidecar image is included in this span. The
+// image-volumes mode creates no copy init containers, so the phase does not
+// fire there. A failed sidecar init reports early with is_error set.
+func (t *kubernetesSetupPhaseTracker) observeSidecarPrep(ctx context.Context, pod *corev1.Pod) {
+	expected := 0
+	for _, container := range pod.Spec.InitContainers {
+		if strings.HasPrefix(container.Name, kubernetesSidecarInitPrefix) {
+			expected++
+		}
+	}
+	if expected == 0 {
+		return
+	}
+
+	var start, finish time.Time
+	terminated := 0
+	failed := false
+	for _, status := range pod.Status.InitContainerStatuses {
+		if !strings.HasPrefix(status.Name, kubernetesSidecarInitPrefix) || status.State.Terminated == nil {
+			continue
+		}
+		terminated++
+		term := status.State.Terminated
+		if start.IsZero() || term.StartedAt.Time.Before(start) {
+			start = term.StartedAt.Time
+		}
+		if term.FinishedAt.Time.After(finish) {
+			finish = term.FinishedAt.Time
+		}
+		if term.ExitCode != 0 {
+			failed = true
+		}
+	}
+	if terminated == 0 {
+		return
+	}
+	if failed || terminated == expected {
+		t.report(ctx, SetupEventSidecarPrep, start, finish, failed)
+	}
+}
+
+// observeSetupCommand reports the operator-configured setup init container's
+// run time once it terminates.
+func (t *kubernetesSetupPhaseTracker) observeSetupCommand(ctx context.Context, pod *corev1.Pod) {
+	for _, status := range pod.Status.InitContainerStatuses {
+		if status.Name != kubernetesSetupContainerName || status.State.Terminated == nil {
+			continue
+		}
+		term := status.State.Terminated
+		t.report(ctx, SetupEventSetupCommand, term.StartedAt.Time, term.FinishedAt.Time, term.ExitCode != 0)
+		return
+	}
+}
+
+// observeTaskStart reports the span from the end of init to the task
+// container start. This includes the kubelet's pull of the task image.
+func (t *kubernetesSetupPhaseTracker) observeTaskStart(ctx context.Context, pod *corev1.Pod) {
+	var startedAt time.Time
+	for _, status := range pod.Status.ContainerStatuses {
+		if status.Name != kubernetesTaskContainerName {
+			continue
+		}
+		// A terminated state still carries the start time, so a container
+		// that runs faster than the watch delivers updates is not missed.
+		if status.State.Running != nil {
+			startedAt = status.State.Running.StartedAt.Time
+		} else if status.State.Terminated != nil {
+			startedAt = status.State.Terminated.StartedAt.Time
+		}
+		break
+	}
+	if startedAt.IsZero() {
+		return
+	}
+	t.report(ctx, SetupEventContainerStart, t.taskStartAnchor(pod), startedAt, false)
+}
+
+// taskStartAnchor returns the moment the task container start effectively
+// began: the last init container finish when init containers ran, the
+// scheduling time otherwise, and the pod creation time as a final fallback.
+// Native sidecar init containers (restartPolicy Always) never terminate and
+// therefore never move the anchor.
+func (t *kubernetesSetupPhaseTracker) taskStartAnchor(pod *corev1.Pod) time.Time {
+	var anchor time.Time
+	for _, status := range pod.Status.InitContainerStatuses {
+		if status.State.Terminated != nil && status.State.Terminated.FinishedAt.Time.After(anchor) {
+			anchor = status.State.Terminated.FinishedAt.Time
+		}
+	}
+	if !anchor.IsZero() {
+		return anchor
+	}
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodScheduled && condition.Status == corev1.ConditionTrue {
+			return condition.LastTransitionTime.Time
+		}
+	}
+	return pod.CreationTimestamp.Time
+}

--- a/internal/worker/kubernetes_setup_events.go
+++ b/internal/worker/kubernetes_setup_events.go
@@ -8,12 +8,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-const (
-	kubernetesTaskContainerName  = "task"
-	kubernetesSetupContainerName = "setup"
-	kubernetesSidecarInitPrefix  = "copy-sidecar-"
-)
-
 // kubernetesSetupPhaseTracker derives task setup phase durations from pod
 // status snapshots and reports each phase once. The kubelet performs the
 // image pulls and container starts for this backend, so the worker cannot

--- a/internal/worker/kubernetes_setup_events_test.go
+++ b/internal/worker/kubernetes_setup_events_test.go
@@ -92,10 +92,10 @@ func TestKubernetesSetupPhaseTrackerReportsPhasesOnce(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(base)},
 		Spec: corev1.PodSpec{
 			InitContainers: []corev1.Container{
-				{Name: "copy-sidecar-0"},
-				{Name: "setup"},
+				{Name: kubernetesSidecarInitPrefix + "0"},
+				{Name: kubernetesSetupContainerName},
 			},
-			Containers: []corev1.Container{{Name: "task"}},
+			Containers: []corev1.Container{{Name: kubernetesTaskContainerName}},
 		},
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{
@@ -106,12 +106,12 @@ func TestKubernetesSetupPhaseTrackerReportsPhasesOnce(t *testing.T) {
 				},
 			},
 			InitContainerStatuses: []corev1.ContainerStatus{
-				terminatedInitStatus("copy-sidecar-0", base.Add(6*time.Second), base.Add(18*time.Second), 0),
-				terminatedInitStatus("setup", base.Add(18*time.Second), base.Add(25*time.Second), 0),
+				terminatedInitStatus(kubernetesSidecarInitPrefix+"0", base.Add(6*time.Second), base.Add(18*time.Second), 0),
+				terminatedInitStatus(kubernetesSetupContainerName, base.Add(18*time.Second), base.Add(25*time.Second), 0),
 			},
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name: "task",
+					Name: kubernetesTaskContainerName,
 					State: corev1.ContainerState{
 						Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(base.Add(30 * time.Second))},
 					},
@@ -159,7 +159,7 @@ func TestKubernetesSetupPhaseTrackerImageVolumesMode(t *testing.T) {
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(base)},
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "task"}},
+			Containers: []corev1.Container{{Name: kubernetesTaskContainerName}},
 		},
 		Status: corev1.PodStatus{
 			Conditions: []corev1.PodCondition{
@@ -171,7 +171,7 @@ func TestKubernetesSetupPhaseTrackerImageVolumesMode(t *testing.T) {
 			},
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name: "task",
+					Name: kubernetesTaskContainerName,
 					State: corev1.ContainerState{
 						Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(base.Add(20 * time.Second))},
 					},
@@ -205,14 +205,14 @@ func TestKubernetesSetupPhaseTrackerReportsSidecarFailure(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(base)},
 		Spec: corev1.PodSpec{
 			InitContainers: []corev1.Container{
-				{Name: "copy-sidecar-0"},
-				{Name: "copy-sidecar-1"},
+				{Name: kubernetesSidecarInitPrefix + "0"},
+				{Name: kubernetesSidecarInitPrefix + "1"},
 			},
-			Containers: []corev1.Container{{Name: "task"}},
+			Containers: []corev1.Container{{Name: kubernetesTaskContainerName}},
 		},
 		Status: corev1.PodStatus{
 			InitContainerStatuses: []corev1.ContainerStatus{
-				terminatedInitStatus("copy-sidecar-0", base.Add(time.Second), base.Add(4*time.Second), 1),
+				terminatedInitStatus(kubernetesSidecarInitPrefix+"0", base.Add(time.Second), base.Add(4*time.Second), 1),
 			},
 		},
 	}
@@ -240,14 +240,14 @@ func TestKubernetesSetupPhaseTrackerWaitsForAllSidecars(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(base)},
 		Spec: corev1.PodSpec{
 			InitContainers: []corev1.Container{
-				{Name: "copy-sidecar-0"},
-				{Name: "copy-sidecar-1"},
+				{Name: kubernetesSidecarInitPrefix + "0"},
+				{Name: kubernetesSidecarInitPrefix + "1"},
 			},
-			Containers: []corev1.Container{{Name: "task"}},
+			Containers: []corev1.Container{{Name: kubernetesTaskContainerName}},
 		},
 		Status: corev1.PodStatus{
 			InitContainerStatuses: []corev1.ContainerStatus{
-				terminatedInitStatus("copy-sidecar-0", base.Add(time.Second), base.Add(4*time.Second), 0),
+				terminatedInitStatus(kubernetesSidecarInitPrefix+"0", base.Add(time.Second), base.Add(4*time.Second), 0),
 			},
 		},
 	}
@@ -259,7 +259,7 @@ func TestKubernetesSetupPhaseTrackerWaitsForAllSidecars(t *testing.T) {
 	}
 
 	pod.Status.InitContainerStatuses = append(pod.Status.InitContainerStatuses,
-		terminatedInitStatus("copy-sidecar-1", base.Add(4*time.Second), base.Add(9*time.Second), 0))
+		terminatedInitStatus(kubernetesSidecarInitPrefix+"1", base.Add(4*time.Second), base.Add(9*time.Second), 0))
 	tracker.observePod(context.Background(), pod)
 	captured.waitForEvents(t, 1)
 

--- a/internal/worker/kubernetes_setup_events_test.go
+++ b/internal/worker/kubernetes_setup_events_test.go
@@ -1,0 +1,282 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/warpdotdev/oz-agent-worker/internal/types"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// capturedSetupEvents collects client events received by a stub server.
+// reportPhase sends asynchronously, so readers must poll via waitForEvents.
+type capturedSetupEvents struct {
+	mu     sync.Mutex
+	events map[string]clientEventRequest
+}
+
+func (c *capturedSetupEvents) handler() http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var body clientEventRequest
+		if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+			c.mu.Lock()
+			c.events[body.EventName] = body
+			c.mu.Unlock()
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func (c *capturedSetupEvents) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.events)
+}
+
+func (c *capturedSetupEvents) get(name string) (clientEventRequest, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	event, ok := c.events[name]
+	return event, ok
+}
+
+func (c *capturedSetupEvents) waitForEvents(t *testing.T, want int) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.count() >= want {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %d events, got %d", want, c.count())
+}
+
+func newTrackerForTest(t *testing.T) (*kubernetesSetupPhaseTracker, *capturedSetupEvents) {
+	t.Helper()
+	captured := &capturedSetupEvents{events: make(map[string]clientEventRequest)}
+	server := httptest.NewServer(captured.handler())
+	t.Cleanup(server.Close)
+
+	reporter := newSetupEventReporter(server.URL, &types.TaskAssignmentMessage{
+		TaskID:  "task-123",
+		EnvVars: map[string]string{warpAPIKeyEnv: "api-key"},
+	})
+	return newKubernetesSetupPhaseTracker(reporter), captured
+}
+
+func terminatedInitStatus(name string, started, finished time.Time, exitCode int32) corev1.ContainerStatus {
+	return corev1.ContainerStatus{
+		Name: name,
+		State: corev1.ContainerState{
+			Terminated: &corev1.ContainerStateTerminated{
+				StartedAt:  metav1.NewTime(started),
+				FinishedAt: metav1.NewTime(finished),
+				ExitCode:   exitCode,
+			},
+		},
+	}
+}
+
+func TestKubernetesSetupPhaseTrackerReportsPhasesOnce(t *testing.T) {
+	tracker, captured := newTrackerForTest(t)
+	base := time.Date(2026, 8, 12, 15, 35, 0, 0, time.UTC)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(base)},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "copy-sidecar-0"},
+				{Name: "setup"},
+			},
+			Containers: []corev1.Container{{Name: "task"}},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:               corev1.PodScheduled,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(base.Add(5 * time.Second)),
+				},
+			},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				terminatedInitStatus("copy-sidecar-0", base.Add(6*time.Second), base.Add(18*time.Second), 0),
+				terminatedInitStatus("setup", base.Add(18*time.Second), base.Add(25*time.Second), 0),
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "task",
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(base.Add(30 * time.Second))},
+					},
+				},
+			},
+		},
+	}
+
+	tracker.observePod(context.Background(), pod)
+	tracker.observePod(context.Background(), pod)
+	captured.waitForEvents(t, 4)
+
+	wantLatencies := map[string]float64{
+		SetupEventPodSchedule:    5000,  // creation -> scheduled
+		SetupEventSidecarPrep:    12000, // sidecar init start -> finish
+		SetupEventSetupCommand:   7000,  // setup init start -> finish
+		SetupEventContainerStart: 5000,  // last init finish -> task running
+	}
+	for name, wantLatency := range wantLatencies {
+		event, ok := captured.get(name)
+		if !ok {
+			t.Fatalf("missing event %s", name)
+		}
+		if event.Payload.LatencyMS != wantLatency {
+			t.Errorf("%s latency_ms = %v, want %v", name, event.Payload.LatencyMS, wantLatency)
+		}
+		if event.Payload.IsError {
+			t.Errorf("%s is_error = true, want false", name)
+		}
+	}
+
+	// A repeated observation must not report the phases again.
+	tracker.observePod(context.Background(), pod)
+	time.Sleep(50 * time.Millisecond)
+	if captured.count() != 4 {
+		t.Errorf("event count after repeat observation = %d, want 4", captured.count())
+	}
+}
+
+func TestKubernetesSetupPhaseTrackerImageVolumesMode(t *testing.T) {
+	tracker, captured := newTrackerForTest(t)
+	base := time.Date(2026, 8, 12, 15, 35, 0, 0, time.UTC)
+
+	// Image-volumes mode: no init containers at all.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(base)},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "task"}},
+		},
+		Status: corev1.PodStatus{
+			Conditions: []corev1.PodCondition{
+				{
+					Type:               corev1.PodScheduled,
+					Status:             corev1.ConditionTrue,
+					LastTransitionTime: metav1.NewTime(base.Add(2 * time.Second)),
+				},
+			},
+			ContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name: "task",
+					State: corev1.ContainerState{
+						Running: &corev1.ContainerStateRunning{StartedAt: metav1.NewTime(base.Add(20 * time.Second))},
+					},
+				},
+			},
+		},
+	}
+
+	tracker.observePod(context.Background(), pod)
+	captured.waitForEvents(t, 2)
+
+	if _, ok := captured.get(SetupEventSidecarPrep); ok {
+		t.Error("unexpected sidecar prep event without copy init containers")
+	}
+	event, ok := captured.get(SetupEventContainerStart)
+	if !ok {
+		t.Fatal("missing container start event")
+	}
+	// Anchored to the scheduling time when no init containers ran.
+	if event.Payload.LatencyMS != 18000 {
+		t.Errorf("container start latency_ms = %v, want 18000", event.Payload.LatencyMS)
+	}
+}
+
+func TestKubernetesSetupPhaseTrackerReportsSidecarFailure(t *testing.T) {
+	tracker, captured := newTrackerForTest(t)
+	base := time.Date(2026, 8, 12, 15, 35, 0, 0, time.UTC)
+
+	// Two sidecar inits expected, the first one failed: report early with is_error.
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(base)},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "copy-sidecar-0"},
+				{Name: "copy-sidecar-1"},
+			},
+			Containers: []corev1.Container{{Name: "task"}},
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				terminatedInitStatus("copy-sidecar-0", base.Add(time.Second), base.Add(4*time.Second), 1),
+			},
+		},
+	}
+
+	tracker.observePod(context.Background(), pod)
+	captured.waitForEvents(t, 1)
+
+	event, ok := captured.get(SetupEventSidecarPrep)
+	if !ok {
+		t.Fatal("missing sidecar prep event")
+	}
+	if !event.Payload.IsError {
+		t.Error("is_error = false, want true")
+	}
+	if event.Payload.LatencyMS != 3000 {
+		t.Errorf("latency_ms = %v, want 3000", event.Payload.LatencyMS)
+	}
+}
+
+func TestKubernetesSetupPhaseTrackerWaitsForAllSidecars(t *testing.T) {
+	tracker, captured := newTrackerForTest(t)
+	base := time.Date(2026, 8, 12, 15, 35, 0, 0, time.UTC)
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(base)},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{
+				{Name: "copy-sidecar-0"},
+				{Name: "copy-sidecar-1"},
+			},
+			Containers: []corev1.Container{{Name: "task"}},
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{
+				terminatedInitStatus("copy-sidecar-0", base.Add(time.Second), base.Add(4*time.Second), 0),
+			},
+		},
+	}
+
+	tracker.observePod(context.Background(), pod)
+	time.Sleep(50 * time.Millisecond)
+	if captured.count() != 0 {
+		t.Fatalf("event count with one of two sidecars terminated = %d, want 0", captured.count())
+	}
+
+	pod.Status.InitContainerStatuses = append(pod.Status.InitContainerStatuses,
+		terminatedInitStatus("copy-sidecar-1", base.Add(4*time.Second), base.Add(9*time.Second), 0))
+	tracker.observePod(context.Background(), pod)
+	captured.waitForEvents(t, 1)
+
+	event, ok := captured.get(SetupEventSidecarPrep)
+	if !ok {
+		t.Fatal("missing sidecar prep event")
+	}
+	if event.Payload.LatencyMS != 8000 {
+		t.Errorf("latency_ms = %v, want 8000", event.Payload.LatencyMS)
+	}
+}
+
+func TestKubernetesSetupPhaseTrackerNilSafe(t *testing.T) {
+	// A tracker with a nil reporter (reporting disabled) must be a no-op.
+	tracker := newKubernetesSetupPhaseTracker(nil)
+	tracker.observePod(context.Background(), &corev1.Pod{})
+
+	var nilTracker *kubernetesSetupPhaseTracker
+	nilTracker.observePod(context.Background(), &corev1.Pod{})
+}

--- a/internal/worker/kubernetes_test.go
+++ b/internal/worker/kubernetes_test.go
@@ -239,7 +239,7 @@ func TestInspectPodFailureReportsContainerExitDiagnostics(t *testing.T) {
 			Phase: corev1.PodFailed,
 			ContainerStatuses: []corev1.ContainerStatus{
 				{
-					Name: "task",
+					Name: kubernetesTaskContainerName,
 					State: corev1.ContainerState{
 						Terminated: &corev1.ContainerStateTerminated{
 							ExitCode: 143,
@@ -281,7 +281,7 @@ func TestInspectPodFailureIgnoresRestartableSidecarExitCodes(t *testing.T) {
 	}
 	podSpec := corev1.PodSpec{
 		InitContainers: []corev1.Container{
-			{Name: "copy-sidecar-0"},
+			{Name: kubernetesSidecarInitPrefix + "0"},
 			{Name: "zookeeper", RestartPolicy: &sidecarPolicy},
 		},
 	}
@@ -314,7 +314,7 @@ func TestInspectPodFailureIgnoresRestartableSidecarExitCodes(t *testing.T) {
 			Status: corev1.PodStatus{
 				InitContainerStatuses: []corev1.ContainerStatus{
 					{
-						Name: "copy-sidecar-0",
+						Name: kubernetesSidecarInitPrefix + "0",
 						State: corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{ExitCode: 1},
 						},
@@ -343,7 +343,7 @@ func TestInspectPodFailureIgnoresRestartableSidecarExitCodes(t *testing.T) {
 				},
 				ContainerStatuses: []corev1.ContainerStatus{
 					{
-						Name: "task",
+						Name: kubernetesTaskContainerName,
 						State: corev1.ContainerState{
 							Terminated: &corev1.ContainerStateTerminated{ExitCode: 2},
 						},
@@ -448,7 +448,7 @@ func TestExecuteTaskSucceedsWhenSidecarExitsBeforeJobComplete(t *testing.T) {
 					},
 					ContainerStatuses: []corev1.ContainerStatus{
 						{
-							Name: "task",
+							Name: kubernetesTaskContainerName,
 							State: corev1.ContainerState{
 								Terminated: &corev1.ContainerStateTerminated{ExitCode: 0},
 							},
@@ -622,7 +622,7 @@ func TestWatchTaskPodsReceivesEvents(t *testing.T) {
 			},
 		},
 		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{Name: "task", Image: "ubuntu:22.04"}},
+			Containers: []corev1.Container{{Name: kubernetesTaskContainerName, Image: "ubuntu:22.04"}},
 		},
 	}
 	if _, err := fakeClient.CoreV1().Pods("agents").Create(context.Background(), pod, metav1.CreateOptions{}); err != nil {
@@ -713,7 +713,7 @@ func TestBuildTaskPodSpecUsesPodTemplateFieldsAndCLIEnv(t *testing.T) {
 				},
 				Containers: []corev1.Container{
 					{
-						Name:            "task",
+						Name:            kubernetesTaskContainerName,
 						ImagePullPolicy: corev1.PullAlways,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -733,7 +733,7 @@ func TestBuildTaskPodSpecUsesPodTemplateFieldsAndCLIEnv(t *testing.T) {
 	}
 
 	mainContainer := corev1.Container{
-		Name:            "task",
+		Name:            kubernetesTaskContainerName,
 		Image:           "ubuntu:22.04",
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-c", "run-task"},
@@ -764,7 +764,7 @@ func TestBuildTaskPodSpecUsesPodTemplateFieldsAndCLIEnv(t *testing.T) {
 
 	var taskContainer *corev1.Container
 	for i := range podSpec.Containers {
-		if podSpec.Containers[i].Name == "task" {
+		if podSpec.Containers[i].Name == kubernetesTaskContainerName {
 			taskContainer = &podSpec.Containers[i]
 			break
 		}
@@ -880,7 +880,7 @@ func TestBuildTaskPodSpecRunnerShapeOverridesPodTemplateResources(t *testing.T) 
 			PodTemplate: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "task",
+						Name: kubernetesTaskContainerName,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
 								corev1.ResourceCPU:    resource.MustParse("500m"),
@@ -894,14 +894,14 @@ func TestBuildTaskPodSpecRunnerShapeOverridesPodTemplateResources(t *testing.T) 
 		},
 	}
 
-	mainContainer := corev1.Container{Name: "task", Image: "ubuntu:22.04"}
+	mainContainer := corev1.Container{Name: kubernetesTaskContainerName, Image: "ubuntu:22.04"}
 	applyInstanceShapeToContainer(&mainContainer, &types.InstanceShape{Vcpus: 4, MemoryGb: 16})
 
 	podSpec := backend.buildTaskPodSpec(nil, nil, mainContainer)
 
 	var tc *corev1.Container
 	for i := range podSpec.Containers {
-		if podSpec.Containers[i].Name == "task" {
+		if podSpec.Containers[i].Name == kubernetesTaskContainerName {
 			tc = &podSpec.Containers[i]
 			break
 		}
@@ -1047,7 +1047,7 @@ func TestExecuteTaskUsesImageVolumesForSidecars(t *testing.T) {
 	if len(createdJob.Spec.Template.Spec.InitContainers) != 1 {
 		t.Fatalf("expected only setup init container, got %d", len(createdJob.Spec.Template.Spec.InitContainers))
 	}
-	if createdJob.Spec.Template.Spec.InitContainers[0].Name != "setup" {
+	if createdJob.Spec.Template.Spec.InitContainers[0].Name != kubernetesSetupContainerName {
 		t.Fatalf("expected setup init container, got %q", createdJob.Spec.Template.Spec.InitContainers[0].Name)
 	}
 	if len(createdJob.Spec.Template.Spec.Volumes) != 2 {
@@ -1207,7 +1207,7 @@ func TestExecuteTaskUsesCopyInitContainersByDefault(t *testing.T) {
 		t.Fatalf("expected copy init container plus setup, got %d", len(createdJob.Spec.Template.Spec.InitContainers))
 	}
 	copyInit := createdJob.Spec.Template.Spec.InitContainers[0]
-	if copyInit.Name != "copy-sidecar-0" {
+	if copyInit.Name != kubernetesSidecarInitPrefix+"0" {
 		t.Fatalf("expected copy-sidecar init container, got %q", copyInit.Name)
 	}
 	if copyInit.Image != "registry.internal/agent:1.0" {

--- a/internal/worker/setup_events.go
+++ b/internal/worker/setup_events.go
@@ -1,0 +1,144 @@
+package worker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warpdotdev/oz-agent-worker/internal/log"
+	"github.com/warpdotdev/oz-agent-worker/internal/types"
+)
+
+const (
+	warpAPIKeyEnv        = "WARP_API_KEY"
+	warpWorkloadTokenEnv = "WARP_WORKLOAD_TOKEN" // #nosec G101 -- environment variable name, not a credential
+
+	cloudAgentIDHeader  = "X-Warp-Cloud-Agent-ID"
+	workloadTokenHeader = "X-Warp-Ambient-Workload-Token" // #nosec G101 -- header name, not a credential
+
+	// Worker-observed setup phases reported as run client events. warp-server
+	// ingests them as setup metrics, labeled with the run's current timeline
+	// phase (oz_run_claimed while the container is still being prepared).
+	// SetupEventContainerStart spans container creation through a successful
+	// start call.
+	SetupEventImagePull      = "setup_worker_image_pull"
+	SetupEventSidecarPrep    = "setup_worker_sidecar_prep"
+	SetupEventContainerStart = "setup_worker_container_start"
+
+	setupEventRequestTimeout = 5 * time.Second
+)
+
+// setupEventReporter reports worker-observed task setup phase durations to
+// warp-server's run client-events endpoint. Reporting is best-effort: failures
+// are logged and never affect task execution.
+type setupEventReporter struct {
+	httpClient    *http.Client
+	serverRootURL string
+	runID         string
+	apiKey        string
+	workloadToken string
+}
+
+// newSetupEventReporter builds a reporter from the worker's server root URL and
+// the task assignment's credentials. It returns nil (a valid no-op reporter)
+// when the server root URL or the per-task API key is unavailable.
+func newSetupEventReporter(serverRootURL string, assignment *types.TaskAssignmentMessage) *setupEventReporter {
+	if serverRootURL == "" || assignment == nil {
+		return nil
+	}
+	apiKey := assignment.EnvVars[warpAPIKeyEnv]
+	if apiKey == "" {
+		return nil
+	}
+	return &setupEventReporter{
+		httpClient:    &http.Client{Timeout: setupEventRequestTimeout},
+		serverRootURL: strings.TrimRight(serverRootURL, "/"),
+		runID:         assignment.TaskID,
+		apiKey:        apiKey,
+		workloadToken: assignment.EnvVars[warpWorkloadTokenEnv],
+	}
+}
+
+// reportPhase asynchronously reports one completed setup phase. It is safe to
+// call on a nil reporter and never blocks task execution.
+func (r *setupEventReporter) reportPhase(ctx context.Context, eventName string, start, finish time.Time, isError bool) {
+	if r == nil {
+		return
+	}
+	// Detach from the task context so cancellation of the task (including the
+	// failure that is being reported) does not drop the report.
+	sendCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), setupEventRequestTimeout)
+	go func() {
+		defer cancel()
+		if err := r.send(sendCtx, eventName, start, finish, isError); err != nil {
+			log.Warnf(sendCtx, "Failed to report setup event %s for task %s: %v", eventName, r.runID, err)
+		}
+	}()
+}
+
+type setupMetricPayload struct {
+	StartTS   time.Time `json:"start_ts"`
+	FinishTS  time.Time `json:"finish_ts"`
+	LatencyMS float64   `json:"latency_ms"`
+	IsError   bool      `json:"is_error"`
+}
+
+type clientEventRequest struct {
+	EventUUID string             `json:"event_uuid"`
+	EventName string             `json:"event_name"`
+	Timestamp time.Time          `json:"timestamp"`
+	Payload   setupMetricPayload `json:"payload"`
+}
+
+// send synchronously posts one setup event to the run client-events endpoint.
+func (r *setupEventReporter) send(ctx context.Context, eventName string, start, finish time.Time, isError bool) error {
+	body, err := json.Marshal(clientEventRequest{
+		EventUUID: uuid.NewString(),
+		EventName: eventName,
+		Timestamp: finish,
+		Payload: setupMetricPayload{
+			StartTS:   start,
+			FinishTS:  finish,
+			LatencyMS: float64(finish.Sub(start).Milliseconds()),
+			IsError:   isError,
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to marshal client event: %w", err)
+	}
+
+	endpoint := fmt.Sprintf("%s/api/v1/agent/runs/%s/client-events", r.serverRootURL, url.PathEscape(r.runID))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("failed to build client event request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+r.apiKey)
+	req.Header.Set(cloudAgentIDHeader, r.runID)
+	if r.workloadToken != "" {
+		req.Header.Set(workloadTokenHeader, r.workloadToken)
+	}
+
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if closeErr := resp.Body.Close(); closeErr != nil {
+			log.Warnf(ctx, "Failed to close client event response body: %v", closeErr)
+		}
+	}()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return fmt.Errorf("client event request returned status %d: %s", resp.StatusCode, string(respBody))
+	}
+	return nil
+}

--- a/internal/worker/setup_events.go
+++ b/internal/worker/setup_events.go
@@ -74,6 +74,28 @@ func newSetupEventReporter(serverRootURL string, assignment *types.TaskAssignmen
 	}
 }
 
+// startPhase begins timing one setup phase and returns a completion func that
+// reports the phase result. See startPhaseIf for the reporting rules.
+func (r *setupEventReporter) startPhase(ctx context.Context, eventName string) func(isError bool) {
+	return r.startPhaseIf(ctx, eventName, true)
+}
+
+// startPhaseIf begins timing one setup phase and returns a completion func
+// that reports the phase with the elapsed wall-clock time. The func skips the
+// report when shouldReport is false, and when the context was cancelled: a
+// cancelled phase is neither a success nor a failure, so recording it would
+// skew both the duration and the failure-rate metrics. Both funcs are safe to
+// call on a nil reporter.
+func (r *setupEventReporter) startPhaseIf(ctx context.Context, eventName string, shouldReport bool) func(isError bool) {
+	start := time.Now()
+	return func(isError bool) {
+		if r == nil || !shouldReport || ctx.Err() != nil {
+			return
+		}
+		r.reportPhase(ctx, eventName, start, time.Now(), isError)
+	}
+}
+
 // reportPhase asynchronously reports one completed setup phase. It is safe to
 // call on a nil reporter and never blocks task execution.
 func (r *setupEventReporter) reportPhase(ctx context.Context, eventName string, start, finish time.Time, isError bool) {

--- a/internal/worker/setup_events.go
+++ b/internal/worker/setup_events.go
@@ -27,10 +27,18 @@ const (
 	// ingests them as setup metrics, labeled with the run's current timeline
 	// phase (oz_run_claimed while the container is still being prepared).
 	// SetupEventContainerStart spans container creation through a successful
-	// start call.
+	// start call on the Docker backend, and the span from the end of init
+	// (or scheduling) to the task container start on the Kubernetes backend.
 	SetupEventImagePull      = "setup_worker_image_pull"
 	SetupEventSidecarPrep    = "setup_worker_sidecar_prep"
 	SetupEventContainerStart = "setup_worker_container_start"
+
+	// Kubernetes-backend phases. SetupEventJobCreate is timed directly around
+	// the Job create call; the other phases are derived from pod status by
+	// kubernetesSetupPhaseTracker.
+	SetupEventJobCreate    = "setup_worker_job_create"
+	SetupEventPodSchedule  = "setup_worker_pod_schedule"
+	SetupEventSetupCommand = "setup_worker_setup_command"
 
 	setupEventRequestTimeout = 5 * time.Second
 )

--- a/internal/worker/setup_events_test.go
+++ b/internal/worker/setup_events_test.go
@@ -161,8 +161,77 @@ func TestSetupEventReporterSend(t *testing.T) {
 	})
 }
 
+func TestSetupEventReporterStartPhase(t *testing.T) {
+	newReporter := func(t *testing.T) (*setupEventReporter, *capturedSetupEvents) {
+		t.Helper()
+		captured := &capturedSetupEvents{events: make(map[string]clientEventRequest)}
+		server := httptest.NewServer(captured.handler())
+		t.Cleanup(server.Close)
+		reporter := newSetupEventReporter(server.URL, &types.TaskAssignmentMessage{
+			TaskID:  "task-123",
+			EnvVars: map[string]string{warpAPIKeyEnv: "api-key"},
+		})
+		return reporter, captured
+	}
+
+	t.Run("reports a completed phase", func(t *testing.T) {
+		reporter, captured := newReporter(t)
+		done := reporter.startPhase(context.Background(), SetupEventImagePull)
+		done(false)
+		captured.waitForEvents(t, 1)
+		event, ok := captured.get(SetupEventImagePull)
+		if !ok {
+			t.Fatal("missing image pull event")
+		}
+		if event.Payload.IsError {
+			t.Error("is_error = true, want false")
+		}
+	})
+
+	t.Run("reports a failed phase", func(t *testing.T) {
+		reporter, captured := newReporter(t)
+		reporter.startPhase(context.Background(), SetupEventContainerStart)(true)
+		captured.waitForEvents(t, 1)
+		event, ok := captured.get(SetupEventContainerStart)
+		if !ok {
+			t.Fatal("missing container start event")
+		}
+		if !event.Payload.IsError {
+			t.Error("is_error = false, want true")
+		}
+	})
+
+	t.Run("skips a phase interrupted by cancellation", func(t *testing.T) {
+		reporter, captured := newReporter(t)
+		ctx, cancel := context.WithCancel(context.Background())
+		done := reporter.startPhase(ctx, SetupEventImagePull)
+		// The task was cancelled while the phase ran: the phase must not be
+		// recorded as a failure (or as a truncated success).
+		cancel()
+		done(true)
+		time.Sleep(50 * time.Millisecond)
+		if captured.count() != 0 {
+			t.Errorf("event count after cancelled phase = %d, want 0", captured.count())
+		}
+	})
+
+	t.Run("skips a phase when shouldReport is false", func(t *testing.T) {
+		reporter, captured := newReporter(t)
+		// Mirrors the Docker backend skipping sidecar prep for tasks without
+		// sidecars.
+		done := reporter.startPhaseIf(context.Background(), SetupEventSidecarPrep, false)
+		done(false)
+		time.Sleep(50 * time.Millisecond)
+		if captured.count() != 0 {
+			t.Errorf("event count for skipped phase = %d, want 0", captured.count())
+		}
+	})
+}
+
 func TestSetupEventReporterNilSafe(t *testing.T) {
 	var reporter *setupEventReporter
 	// Must not panic.
 	reporter.reportPhase(context.Background(), SetupEventImagePull, time.Now(), time.Now(), false)
+	reporter.startPhase(context.Background(), SetupEventImagePull)(false)
+	reporter.startPhaseIf(context.Background(), SetupEventSidecarPrep, true)(true)
 }

--- a/internal/worker/setup_events_test.go
+++ b/internal/worker/setup_events_test.go
@@ -1,0 +1,168 @@
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warpdotdev/oz-agent-worker/internal/types"
+)
+
+func TestNewSetupEventReporter(t *testing.T) {
+	assignment := &types.TaskAssignmentMessage{
+		TaskID: "task-123",
+		EnvVars: map[string]string{
+			warpAPIKeyEnv:        "api-key",
+			warpWorkloadTokenEnv: "workload-token",
+		},
+	}
+
+	tests := []struct {
+		name          string
+		serverRootURL string
+		assignment    *types.TaskAssignmentMessage
+		wantNil       bool
+	}{
+		{name: "enabled", serverRootURL: "https://app.warp.dev", assignment: assignment},
+		{name: "trailing slash trimmed", serverRootURL: "https://app.warp.dev/", assignment: assignment},
+		{name: "no server root URL", serverRootURL: "", assignment: assignment, wantNil: true},
+		{name: "nil assignment", serverRootURL: "https://app.warp.dev", assignment: nil, wantNil: true},
+		{
+			name:          "no API key",
+			serverRootURL: "https://app.warp.dev",
+			assignment:    &types.TaskAssignmentMessage{TaskID: "task-123"},
+			wantNil:       true,
+		},
+		{
+			name:          "workload token optional",
+			serverRootURL: "https://app.warp.dev",
+			assignment: &types.TaskAssignmentMessage{
+				TaskID:  "task-123",
+				EnvVars: map[string]string{warpAPIKeyEnv: "api-key"},
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			reporter := newSetupEventReporter(tc.serverRootURL, tc.assignment)
+			if (reporter == nil) != tc.wantNil {
+				t.Fatalf("newSetupEventReporter() nil = %v, want %v", reporter == nil, tc.wantNil)
+			}
+			if reporter != nil && reporter.serverRootURL != "https://app.warp.dev" {
+				t.Errorf("serverRootURL = %q, want %q", reporter.serverRootURL, "https://app.warp.dev")
+			}
+		})
+	}
+}
+
+func TestSetupEventReporterSend(t *testing.T) {
+	start := time.Date(2026, 8, 12, 15, 35, 0, 0, time.UTC)
+	finish := start.Add(24598 * time.Millisecond)
+
+	t.Run("posts a well-formed client event", func(t *testing.T) {
+		var gotRequest *http.Request
+		var gotBody clientEventRequest
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotRequest = r.Clone(context.Background())
+			if err := json.NewDecoder(r.Body).Decode(&gotBody); err != nil {
+				t.Errorf("failed to decode request body: %v", err)
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		reporter := newSetupEventReporter(server.URL, &types.TaskAssignmentMessage{
+			TaskID: "task-123",
+			EnvVars: map[string]string{
+				warpAPIKeyEnv:        "api-key",
+				warpWorkloadTokenEnv: "workload-token",
+			},
+		})
+
+		if err := reporter.send(context.Background(), SetupEventImagePull, start, finish, false); err != nil {
+			t.Fatalf("send() error = %v", err)
+		}
+
+		if wantPath := "/api/v1/agent/runs/task-123/client-events"; gotRequest.URL.Path != wantPath {
+			t.Errorf("path = %q, want %q", gotRequest.URL.Path, wantPath)
+		}
+		if got := gotRequest.Header.Get("Authorization"); got != "Bearer api-key" {
+			t.Errorf("Authorization = %q, want %q", got, "Bearer api-key")
+		}
+		if got := gotRequest.Header.Get(cloudAgentIDHeader); got != "task-123" {
+			t.Errorf("%s = %q, want %q", cloudAgentIDHeader, got, "task-123")
+		}
+		if got := gotRequest.Header.Get(workloadTokenHeader); got != "workload-token" {
+			t.Errorf("%s = %q, want %q", workloadTokenHeader, got, "workload-token")
+		}
+		if gotBody.EventName != SetupEventImagePull {
+			t.Errorf("event_name = %q, want %q", gotBody.EventName, SetupEventImagePull)
+		}
+		if _, err := uuid.Parse(gotBody.EventUUID); err != nil {
+			t.Errorf("event_uuid %q is not a valid UUID: %v", gotBody.EventUUID, err)
+		}
+		if !gotBody.Timestamp.Equal(finish) {
+			t.Errorf("timestamp = %v, want %v", gotBody.Timestamp, finish)
+		}
+		if !gotBody.Payload.StartTS.Equal(start) || !gotBody.Payload.FinishTS.Equal(finish) {
+			t.Errorf("payload range = [%v, %v], want [%v, %v]", gotBody.Payload.StartTS, gotBody.Payload.FinishTS, start, finish)
+		}
+		if gotBody.Payload.LatencyMS != 24598 {
+			t.Errorf("latency_ms = %v, want %v", gotBody.Payload.LatencyMS, 24598)
+		}
+		if gotBody.Payload.IsError {
+			t.Errorf("is_error = true, want false")
+		}
+	})
+
+	t.Run("omits workload token header when absent", func(t *testing.T) {
+		var gotToken *string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			values := r.Header.Values(workloadTokenHeader)
+			if len(values) > 0 {
+				gotToken = &values[0]
+			}
+			w.WriteHeader(http.StatusNoContent)
+		}))
+		defer server.Close()
+
+		reporter := newSetupEventReporter(server.URL, &types.TaskAssignmentMessage{
+			TaskID:  "task-123",
+			EnvVars: map[string]string{warpAPIKeyEnv: "api-key"},
+		})
+
+		if err := reporter.send(context.Background(), SetupEventContainerStart, start, finish, true); err != nil {
+			t.Fatalf("send() error = %v", err)
+		}
+		if gotToken != nil {
+			t.Errorf("workload token header = %q, want unset", *gotToken)
+		}
+	})
+
+	t.Run("returns error on non-2xx response", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "forbidden", http.StatusForbidden)
+		}))
+		defer server.Close()
+
+		reporter := newSetupEventReporter(server.URL, &types.TaskAssignmentMessage{
+			TaskID:  "task-123",
+			EnvVars: map[string]string{warpAPIKeyEnv: "api-key"},
+		})
+
+		if err := reporter.send(context.Background(), SetupEventSidecarPrep, start, finish, false); err == nil {
+			t.Fatal("send() error = nil, want non-nil")
+		}
+	})
+}
+
+func TestSetupEventReporterNilSafe(t *testing.T) {
+	var reporter *setupEventReporter
+	// Must not panic.
+	reporter.reportPhase(context.Background(), SetupEventImagePull, time.Now(), time.Now(), false)
+}

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -584,6 +584,7 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		DockerImage:   dockerImage,
 		Sidecars:      sidecars,
 		InstanceShape: assignment.InstanceShape,
+		SetupEvents:   newSetupEventReporter(w.config.ServerRootURL, assignment),
 	}
 }
 

--- a/internal/worker/worker.go
+++ b/internal/worker/worker.go
@@ -575,6 +575,18 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		}
 	}
 
+	setupEvents := newSetupEventReporter(w.config.ServerRootURL, assignment)
+	if setupEvents == nil {
+		// Warn once per task: a fleet-wide config or credential change that
+		// disables setup event reporting must be visible in the worker logs,
+		// not silently drop the setup metrics.
+		reason := "the worker has no server root URL configured"
+		if w.config.ServerRootURL != "" {
+			reason = warpAPIKeyEnv + " is not present in the task assignment env vars"
+		}
+		log.Warnf(w.ctx, "Setup event reporting is disabled for task %s: %s", assignment.TaskID, reason)
+	}
+
 	return &TaskParams{
 		TaskID:        assignment.TaskID,
 		ExecutionID:   assignment.ExecutionID,
@@ -584,7 +596,7 @@ func (w *Worker) prepareTaskParams(assignment *types.TaskAssignmentMessage) *Tas
 		DockerImage:   dockerImage,
 		Sidecars:      sidecars,
 		InstanceShape: assignment.InstanceShape,
-		SetupEvents:   newSetupEventReporter(w.config.ServerRootURL, assignment),
+		SetupEvents:   setupEvents,
 	}
 }
 


### PR DESCRIPTION
## Summary
The worker reports the duration of each setup phase to warp-server as run client events, for the Docker and Kubernetes backends. This closes the observability gap between the `oz_run_claimed` and `worker_container_ready` timeline events. Before this change, that window was opaque: the worker sent no signals between the task claim and the first API call from the container.

## Changes
- Add `setupEventReporter` (`internal/worker/setup_events.go`). It sends one client event for each completed setup phase to `POST /api/v1/agent/runs/{runId}/client-events`. It authenticates with the per-task API key and the workload token from the task assignment.
- Report three phases from the Docker backend:
  - `setup_worker_image_pull`: the image pull, including the no-op pull when the image is cached.
  - `setup_worker_sidecar_prep`: the sidecar volume preparation, including the sidecar image pull.
  - `setup_worker_container_start`: the container create call through the container start call.
- Report five phases from the Kubernetes backend. The kubelet performs the pulls and the starts, so a tracker (`internal/worker/kubernetes_setup_events.go`) derives the phases from pod status timestamps delivered by the existing pod watch and safety poll:
  - `setup_worker_job_create`: the Job create API call, timed directly.
  - `setup_worker_pod_schedule`: pod creation to the `PodScheduled` condition. This surfaces node capacity and autoscaler waits.
  - `setup_worker_sidecar_prep`: the first `copy-sidecar-*` init container start to the last finish, including the kubelet's sidecar image pulls. Absent in image-volumes mode.
  - `setup_worker_setup_command`: the `setup` init container run time, when a setup command is configured.
  - `setup_worker_container_start`: the end of init (or scheduling) to the `task` container start, including the kubelet's task image pull.
- Report each phase on failure with `is_error: true`. The Kubernetes tracker reports each phase one time; repeated watch deliveries do not duplicate events, and pod-derived timestamps keep latencies accurate when a watch update arrives late.
- Add the reporter to `TaskParams`. The field can be nil, and all methods are safe on a nil reporter.
- Promote `github.com/google/uuid` to a direct dependency.

## Where the data lands
The server ingests each event as a `ClientSetupMetricPayload` and needs no changes. The events appear in the metrics `ambient_agents/client/events` and `ambient_agents/client/event_latency_ms` with `timeline_phase="oz_run_claimed"`, next to the existing `setup_*` events that the in-container client reports for the later phases.

## Notes
- Reporting is best-effort and asynchronous. A report failure or a slow server does not delay or fail the task.
- The direct and command backends do not report these events yet. The command backend hands execution to an operator runtime, which can post the same events itself with the credentials in the dispatch payload.
- Kubernetes pod timestamps have one-second granularity, so very short phases can report 0 ms.

## Testing
- `go build ./...`, `go vet ./...`, and `go test ./...` pass.
- Unit tests cover the reporter construction gating, the request path, the auth headers, the payload fields, the non-2xx error path, and nil-receiver safety.
- Kubernetes tracker tests cover the full phase lifecycle with once-only reporting, the image-volumes mode, a failed sidecar init with `is_error`, the wait for all sidecar init containers, and nil safety.

_Conversation: https://staging.warp.dev/conversation/bfa633f7-0c7d-45e4-bd78-f43a0f2865be_
_Run: https://oz.staging.warp.dev/runs/019ff6db-8344-7d14-93bd-f3b596c0aa85_

_This PR was generated with [Oz](https://warp.dev/oz)._
