### PR TITLE
Bump Go 1.26.5 -> 1.26.7 to fix CVE-2026-39821

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.7-alpine AS builder
 
 # VERSION is stamped into the binary via -ldflags="-X main.Version=...".
 # CI passes the release tag (or commit SHA) here so the value reported by

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/warpdotdev/oz-agent-worker
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/alecthomas/kong v1.13.0


### PR DESCRIPTION
Fixes [CVE-2026-39821](https://nvd.nist.gov/vuln/detail/CVE-2026-39821) ([GO-2026-5026](https://pkg.go.dev/vuln/GO-2026-5026)) flagged on the `oz-agent-worker` image in Artifact Registry: idna Punycode privilege escalation, fixed in Go 1.26.6; bumping to 1.26.7 (latest patch).

Changes: `Dockerfile` builder `golang:1.26.5-alpine` -> `golang:1.26.7-alpine`, `go.mod` directive `1.26.5` -> `1.26.7`.

Validation: `go build ./...`, `go vet ./...` clean.

Conversation: https://staging.warp.dev/conversation/1fd74fa6-b374-4804-ba14-bbf01037b994

Co-Authored-By: Warp <agent@warp.dev>