### PR TITLE
Bump Go toolchain to 1.26.6 (CVE-2026-39821)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.26.6-alpine AS builder
 
 # VERSION is stamped into the binary via -ldflags="-X main.Version=...".
 # CI passes the release tag (or commit SHA) here so the value reported by

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/warpdotdev/oz-agent-worker
 
-go 1.26.5
+go 1.26.6
 
 require (
 	github.com/alecthomas/kong v1.13.0


### PR DESCRIPTION
## Summary
Bumps the Go toolchain from 1.26.5 to 1.26.6 to remediate **CVE-2026-39821**, a critical privilege-escalation bug in `golang.org/x/net/idna` that ships in the Go toolchain. 1.26.6 is the earliest patched 1.26.x release.

## Changes
- `go.mod`: `go 1.26.5` -> `go 1.26.6`
- `Dockerfile`: builder base image `golang:1.26.5-alpine` -> `golang:1.26.6-alpine`

`golang.org/x/net` is already at v0.55.0 (patched), so only the toolchain bump is needed.

## Validation
- `go build ./...` passes on 1.26.6.

## Scanner findings cleared
- warp-public-images/oz-agent-worker container scan finding for CVE-2026-39821.

Co-Authored-By: Warp <agent@warp.dev>